### PR TITLE
update docker file for owl-light

### DIFF
--- a/docker/owl-light/Dockerfile
+++ b/docker/owl-light/Dockerfile
@@ -2,7 +2,7 @@ FROM node:7
 
 MAINTAINER masato@cepave.com
 
-RUN npm install yarn -g
+RUN which yarn
 
 RUN useradd -m owl
 


### PR DESCRIPTION
update docker build file, `npm install yarn -g` line will cause docker-image build failed