### PR TITLE
[api] fix login conflict with new dashboard & owl-light frontend page

### DIFF
--- a/modules/api/app/controller/uic/session_controller.go
+++ b/modules/api/app/controller/uic/session_controller.go
@@ -11,14 +11,19 @@ import (
 	"github.com/open-falcon/falcon-plus/modules/api/app/utils"
 )
 
+type APILoginInput struct {
+	Name   string `json:"name"  form:"name" binding:"required"`
+	Password string `json:"password"  form:"password" binding:"required"`
+}
 func Login(c *gin.Context) {
-	name := c.DefaultPostForm("name", "")
-	password := c.DefaultPostForm("password", "")
-
-	if name == "" || password == "" {
+	inputs := APILoginInput{}
+	if err := c.Bind(&inputs) ; err != nil {
 		h.JSONR(c, badstatus, "name or password is blank")
 		return
 	}
+	name := inputs.Name
+	password := inputs.Password
+
 	user := uic.User{
 		Name: name,
 	}


### PR DESCRIPTION
目前falcon+ (python版) 和 owl-light的前端页面的登入方式有一点不同.
所以我将这边的api改為两边都可以相容的模式. 

![testresult](https://cloud.githubusercontent.com/assets/4387822/24241384/a00af6e4-0fef-11e7-9a53-e0d9add467fb.jpeg)
