### PR TITLE
graph缓存队列控制和持久化优化

### DIFF
--- a/modules/graph/cron/clean.go
+++ b/modules/graph/cron/clean.go
@@ -74,7 +74,7 @@ func DeleteInvalidHistory() int {
 
 	deleteKeys := make([]string, 0)
 	historyCache.RLock()
-	for key, _ := range historyCache.M {
+	for key := range historyCache.M {
 		if !index.IndexedItemCache.ContainsKey(key) {
 			deleteKeys = append(deleteKeys, key)
 		}

--- a/modules/graph/cron/clean.go
+++ b/modules/graph/cron/clean.go
@@ -1,0 +1,95 @@
+package cron
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/open-falcon/falcon-plus/modules/graph/g"
+	"github.com/open-falcon/falcon-plus/modules/graph/index"
+	"github.com/open-falcon/falcon-plus/modules/graph/store"
+
+	pfc "github.com/niean/goperfcounter"
+)
+
+func CleanCache() {
+
+	ticker := time.NewTicker(time.Duration(g.CLEAN_CACHE) * time.Second)
+	for {
+		<-ticker.C
+		DeleteInvalidItems()   // 删除无效的GraphItems
+		DeleteInvalidHistory() // 删除无效的HistoryCache
+	}
+}
+
+/*
+
+  概念定义及结构体简谱:
+  ckey = md5_type_step
+  uuid = endpoint/metric/tags/dstype/step
+  md5  = md5(endpoint/metric/tags)
+
+  GraphItems        [idx]  [ckey] [{timestamp, value}, {timestamp, value} ...]
+  HistoryCache      [md5]  [itemFirst, itemSecond]
+  IndexedItemCache  [md5]  {UUID, Item}
+
+*/
+
+// TODO: 删除长期不更新数据(依赖index)
+func DeleteInvalidItems() int {
+
+	graphItems := store.GraphItems
+
+	deleteCnt := 0
+	for idx := 0; idx < graphItems.Size; idx++ {
+		keys := graphItems.KeysByIndex(idx)
+
+		deleteKeys := make([]string, 0)
+		for _, key := range keys {
+			tmp := strings.Split(key, "_") // key = md5_type_step
+			if len(tmp) == 3 && !index.IndexedItemCache.ContainsKey(tmp[0]) {
+				deleteKeys = append(deleteKeys, key)
+			}
+		}
+
+		graphItems.Lock()
+		for _, key := range deleteKeys {
+			delete(graphItems.A[idx], key)
+		}
+		graphItems.Unlock()
+		deleteCnt += len(deleteKeys)
+	}
+
+	pfc.Gauge("GraphItemsCacheCnt", int64(graphItems.Len()))
+	pfc.Gauge("GraphItemsCacheInvalidCnt", int64(deleteCnt))
+	log.Printf("GraphItemsCache: Count=>%d, DeleteInvalid=>%d", graphItems.Len(), deleteCnt)
+
+	return deleteCnt
+}
+
+// TODO: 删除长期不更新数据(依赖index)
+func DeleteInvalidHistory() int {
+
+	historyCache := store.HistoryCache
+
+	deleteKeys := make([]string, 0)
+	historyCache.RLock()
+	for key, _ := range historyCache.M {
+		if !index.IndexedItemCache.ContainsKey(key) {
+			deleteKeys = append(deleteKeys, key)
+		}
+	}
+	historyCache.RUnlock()
+
+	historyCache.Lock()
+	for _, key := range deleteKeys {
+		delete(historyCache.M, key)
+	}
+
+	pfc.Gauge("HistoryCacheCnt", int64(len(historyCache.M)))
+	pfc.Gauge("HistoryCacheInvalidCnt", int64(len(deleteKeys)))
+	log.Printf("HistoryCache: Count=>%d, DeleteInvalid=>%d", len(historyCache.M), len(deleteKeys))
+
+	historyCache.Unlock()
+	return len(deleteKeys)
+}

--- a/modules/graph/cron/clean.go
+++ b/modules/graph/cron/clean.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Xiaomi, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cron
 
 import (

--- a/modules/graph/g/g.go
+++ b/modules/graph/g/g.go
@@ -21,9 +21,10 @@ import (
 // 0.5.4 fix bug of Query.merge
 // 0.5.5 use commom(rm model), fix sync disk
 // 0.5.7 set xff to 0 from 0.5, in order to support irregular step counter
+// 0.5.8 clean GraphItems/historyCache Cache at regular intervals
 
 const (
-	VERSION         = "0.5.7"
+	VERSION         = "0.5.8"
 	GAUGE           = "GAUGE"
 	DERIVE          = "DERIVE"
 	COUNTER         = "COUNTER"
@@ -31,6 +32,7 @@ const (
 	FLUSH_DISK_STEP = 1000    //ms
 	DEFAULT_STEP    = 60      //s
 	MIN_STEP        = 30      //s
+	CLEAN_CACHE     = 86400   //s
 )
 const (
 	GRAPH_F_MISS uint32 = 1 << iota

--- a/modules/graph/g/g.go
+++ b/modules/graph/g/g.go
@@ -22,18 +22,23 @@ import (
 // 0.5.5 use commom(rm model), fix sync disk
 // 0.5.7 set xff to 0 from 0.5, in order to support irregular step counter
 // 0.5.8 clean GraphItems/historyCache Cache at regular intervals
+// 0.5.9 add flush style(flush by number of every counter's monitoring data)
 
 const (
-	VERSION         = "0.5.8"
+	VERSION         = "0.5.9"
 	GAUGE           = "GAUGE"
 	DERIVE          = "DERIVE"
 	COUNTER         = "COUNTER"
-	CACHE_TIME      = 1800000 //ms
-	FLUSH_DISK_STEP = 1000    //ms
 	DEFAULT_STEP    = 60      //s
 	MIN_STEP        = 30      //s
-	CLEAN_CACHE     = 86400   //s
+	CLEAN_CACHE     = 86400   //s the step that clean GraphItems/historyCache Cache
+	CACHE_DELAY     = 1800    //s
+	CACHE_TIME      = 1800000 //ms
+	FLUSH_DISK_STEP = 1000    //ms
+	FLUSH_MIN_COUNT = 6       //  flush counter to disk when its number of monitoring data greater than FLUSH_MIN_COUNT
+	FLUSH_MAX_WAIT  = 86400   //s flush counter to disk if it not be flushed within FLUSH_MAX_WAIT seconds
 )
+
 const (
 	GRAPH_F_MISS uint32 = 1 << iota
 	GRAPH_F_ERR

--- a/modules/graph/g/git.go
+++ b/modules/graph/g/git.go
@@ -1,4 +1,5 @@
 package g
+
 const (
-    COMMIT = "65ff8c9"
+	COMMIT = "gitversion"
 )

--- a/modules/graph/g/git.go
+++ b/modules/graph/g/git.go
@@ -1,5 +1,4 @@
 package g
-
 const (
-	COMMIT = "gitversion"
+    COMMIT = "65ff8c9"
 )

--- a/modules/graph/index/cache.go
+++ b/modules/graph/index/cache.go
@@ -24,7 +24,7 @@ const (
 
 // item缓存
 var (
-	indexedItemCache   = NewIndexCacheBase(DefaultMaxCacheSize)
+	IndexedItemCache   = NewIndexCacheBase(DefaultMaxCacheSize)
 	unIndexedItemCache = NewIndexCacheBase(DefaultMaxCacheSize)
 )
 
@@ -45,7 +45,7 @@ func InitCache() {
 func GetTypeAndStep(endpoint string, counter string) (dsType string, step int, found bool) {
 	// get it from index cache
 	pk := cutils.Md5(fmt.Sprintf("%s/%s", endpoint, counter))
-	if icitem := indexedItemCache.Get(pk); icitem != nil {
+	if icitem := IndexedItemCache.Get(pk); icitem != nil {
 		if item := icitem.(*IndexCacheItem).Item; item != nil {
 			dsType = item.DsType
 			step = item.Step
@@ -137,7 +137,7 @@ func GetCounterFromCache(endpointId int64, counter string) (dsType string, step 
 func startCacheProcUpdateTask() {
 	for {
 		time.Sleep(DefaultCacheProcUpdateTaskSleepInterval)
-		proc.IndexedItemCacheCnt.SetCnt(int64(indexedItemCache.Size()))
+		proc.IndexedItemCacheCnt.SetCnt(int64(IndexedItemCache.Size()))
 		proc.UnIndexedItemCacheCnt.SetCnt(int64(unIndexedItemCache.Size()))
 		proc.EndpointCacheCnt.SetCnt(int64(dbEndpointCache.Size()))
 		proc.CounterCacheCnt.SetCnt(int64(dbEndpointCounterCache.Size()))

--- a/modules/graph/index/index.go
+++ b/modules/graph/index/index.go
@@ -25,10 +25,10 @@ func ReceiveItem(item *cmodel.GraphItem, md5 string) {
 	uuid := item.UUID()
 
 	// 已上报过的数据
-	if indexedItemCache.ContainsKey(md5) {
-		old := indexedItemCache.Get(md5).(*IndexCacheItem)
+	if IndexedItemCache.ContainsKey(md5) {
+		old := IndexedItemCache.Get(md5).(*IndexCacheItem)
 		if uuid == old.UUID { // dsType+step没有发生变化,只更新缓存
-			indexedItemCache.Put(md5, NewIndexCacheItem(uuid, item))
+			IndexedItemCache.Put(md5, NewIndexCacheItem(uuid, item))
 		} else { // dsType+step变化了,当成一个新的增量来处理
 			unIndexedItemCache.Put(md5, NewIndexCacheItem(uuid, item))
 		}
@@ -38,7 +38,7 @@ func ReceiveItem(item *cmodel.GraphItem, md5 string) {
 	// 针对 mysql索引重建场景 做的优化，是否有rrdtool文件存在,如果有 则认为MySQL中已建立索引；
 	rrdFileName := g.RrdFileName(g.Config().RRD.Storage, md5, item.DsType, item.Step)
 	if g.IsRrdFileExist(rrdFileName) {
-		indexedItemCache.Put(md5, NewIndexCacheItem(uuid, item))
+		IndexedItemCache.Put(md5, NewIndexCacheItem(uuid, item))
 		return
 	}
 
@@ -49,7 +49,7 @@ func ReceiveItem(item *cmodel.GraphItem, md5 string) {
 //从graph cache中删除掉某个item, 并删除指定的counter对应的rrd文件
 func RemoveItem(item *cmodel.GraphItem) {
 	md5 := item.Checksum()
-	indexedItemCache.Remove(md5)
+	IndexedItemCache.Remove(md5)
 	unIndexedItemCache.Remove(md5)
 
 	//discard data of memory

--- a/modules/graph/index/index_update_all_task.go
+++ b/modules/graph/index/index_update_all_task.go
@@ -72,7 +72,7 @@ func UpdateIndexOne(endpoint string, metric string, tags map[string]string, dsty
 	md5 := itemDemo.Checksum()
 	uuid := itemDemo.UUID()
 
-	cached := indexedItemCache.Get(md5)
+	cached := IndexedItemCache.Get(md5)
 	if cached == nil {
 		return fmt.Errorf("not found")
 	}
@@ -94,7 +94,7 @@ func UpdateIndexOne(endpoint string, metric string, tags map[string]string, dsty
 
 func updateIndexAll(updateStepInSec int64) int {
 	var ret int = 0
-	if indexedItemCache == nil || indexedItemCache.Size() <= 0 {
+	if IndexedItemCache == nil || IndexedItemCache.Size() <= 0 {
 		return ret
 	}
 
@@ -108,16 +108,16 @@ func updateIndexAll(updateStepInSec int64) int {
 	ts := time.Now().Unix()
 	lastTs := ts - updateStepInSec
 
-	keys := indexedItemCache.Keys()
+	keys := IndexedItemCache.Keys()
 	for _, key := range keys {
-		icitem := indexedItemCache.Get(key)
+		icitem := IndexedItemCache.Get(key)
 		if icitem == nil {
 			continue
 		}
 
 		gitem := icitem.(*IndexCacheItem).Item
 		if gitem.Timestamp < lastTs { //缓存中的数据太旧了,不能用于索引的全量更新
-			indexedItemCache.Remove(key) //在这里做个删除,有点恶心
+			IndexedItemCache.Remove(key) //在这里做个删除,有点恶心
 			continue
 		}
 		// 并发写mysql

--- a/modules/graph/index/index_update_incr_task.go
+++ b/modules/graph/index/index_update_incr_task.go
@@ -61,7 +61,7 @@ func updateIndexIncr() int {
 				if err != nil {
 					proc.IndexUpdateIncrErrorCnt.Incr()
 				} else {
-					indexedItemCache.Put(key, icitem)
+					IndexedItemCache.Put(key, icitem)
 				}
 			}(key, icitem.(*IndexCacheItem), dbConn)
 			ret++

--- a/modules/graph/main.go
+++ b/modules/graph/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/open-falcon/falcon-plus/modules/graph/api"
+	"github.com/open-falcon/falcon-plus/modules/graph/cron"
 	"github.com/open-falcon/falcon-plus/modules/graph/g"
 	"github.com/open-falcon/falcon-plus/modules/graph/http"
 	"github.com/open-falcon/falcon-plus/modules/graph/index"
@@ -85,6 +86,7 @@ func main() {
 	index.Start()
 	// start http server
 	go http.Start()
+	go cron.CleanCache()
 
 	start_signal(os.Getpid(), g.Config())
 }

--- a/modules/graph/rrdtool/sync_disk.go
+++ b/modules/graph/rrdtool/sync_disk.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 func syncDisk() {
-	time.Sleep(time.Second * 300)
+	time.Sleep(time.Second * g.CACHE_DELAY)
 	ticker := time.NewTicker(time.Millisecond * g.FLUSH_DISK_STEP).C
 	var idx int = 0
 

--- a/modules/graph/store/history.go
+++ b/modules/graph/store/history.go
@@ -1,10 +1,9 @@
 package store
 
 import (
+	cmodel "github.com/open-falcon/falcon-plus/common/model"
 	tlist "github.com/toolkits/container/list"
 	tmap "github.com/toolkits/container/nmap"
-
-	cmodel "github.com/open-falcon/falcon-plus/common/model"
 )
 
 const (

--- a/modules/graph/store/store.go
+++ b/modules/graph/store/store.go
@@ -176,6 +176,35 @@ func (this *GraphItemMap) KeysByIndex(idx int) []string {
 	return keys
 }
 
+func (this *GraphItemMap) Back(key string) *cmodel.GraphItem {
+	this.RLock()
+	defer this.RUnlock()
+	idx := hashKey(key) % uint32(this.Size)
+	L, ok := this.A[idx][key]
+	if !ok {
+		return nil
+	}
+
+	back := L.Back()
+	if back == nil {
+		return nil
+	}
+
+	return back.Value.(*cmodel.GraphItem)
+}
+
+// 指定key对应的Item数量
+func (this *GraphItemMap) ItemCnt(key string) int {
+	this.Lock()
+	defer this.Unlock()
+	idx := hashKey(key) % uint32(this.Size)
+	L, ok := this.A[idx][key]
+	if !ok {
+		return 0
+	}
+	return L.Len()
+}
+
 func init() {
 	size := g.CACHE_TIME / g.FLUSH_DISK_STEP
 	if size < 0 {

--- a/modules/graph/store/store.go
+++ b/modules/graph/store/store.go
@@ -28,6 +28,20 @@ func (this *GraphItemMap) Get(key string) (*SafeLinkedList, bool) {
 	return val, ok
 }
 
+// Remove method remove key from GraphItemMap, return true if exists
+func (this *GraphItemMap) Remove(key string) bool {
+	this.Lock()
+	defer this.Unlock()
+	idx := hashKey(key) % uint32(this.Size)
+	_, exists := this.A[idx][key]
+	if !exists {
+		return false
+	}
+
+	delete(this.A[idx], key)
+	return true
+}
+
 func (this *GraphItemMap) Getitems(idx int) map[string]*SafeLinkedList {
 	this.RLock()
 	defer this.RUnlock()
@@ -195,8 +209,8 @@ func (this *GraphItemMap) Back(key string) *cmodel.GraphItem {
 
 // 指定key对应的Item数量
 func (this *GraphItemMap) ItemCnt(key string) int {
-	this.Lock()
-	defer this.Unlock()
+	this.RLock()
+	defer this.RUnlock()
 	idx := hashKey(key) % uint32(this.Size)
 	L, ok := this.A[idx][key]
 	if !ok {


### PR DESCRIPTION
1. commit: 26a128f    graph中使用了GraphItems、HistoryCache缓存队列，随着脏数据积累，内存开销会越来越大，现增加周期性清理工作，有效性参照 IndexedItemCache 缓存队列
2. commit: d9afc26    在一些不规范的使用场景，大量脏数据会被上报（数据不连续，偶尔一两个点），会严重消耗RRD和持久化性能，现增加数据点的数量阀值，只有在超过阀值、或超过一定时间（保护性）、或进程退出时强制持久化存储