### PR TITLE
net.port.listen also check udp port

### DIFF
--- a/modules/agent/funcs/portstat.go
+++ b/modules/agent/funcs/portstat.go
@@ -17,13 +17,13 @@ func PortMetrics() (L []*model.MetricValue) {
 		return
 	}
 
-	allTcpListeningPorts, err := nux.TcpPorts()
+	allTcpPorts, err := nux.TcpPorts()
 	if err != nil {
 		log.Println(err)
 		return
 	}
 
-	allUdpListeningPorts, err := nux.UdpPorts()
+	allUdpPorts, err := nux.UdpPorts()
 	if err != nil {
 		log.Println(err)
 		return
@@ -31,9 +31,7 @@ func PortMetrics() (L []*model.MetricValue) {
 
 	for i := 0; i < sz; i++ {
 		tags := fmt.Sprintf("port=%d", reportPorts[i])
-		if slice.ContainsInt64(allTcpListeningPorts, reportPorts[i]) {
-			L = append(L, GaugeValue(g.NET_PORT_LISTEN, 1, tags))
-		} else if slice.ContainsInt64(allUdpListeningPorts, reportPorts[i]) {
+		if slice.ContainsInt64(allTcpPorts, reportPorts[i]) || slice.ContainsInt64(allUdpPorts, reportPorts[i]) {
 			L = append(L, GaugeValue(g.NET_PORT_LISTEN, 1, tags))
 		} else {
 			L = append(L, GaugeValue(g.NET_PORT_LISTEN, 0, tags))

--- a/modules/agent/funcs/portstat.go
+++ b/modules/agent/funcs/portstat.go
@@ -17,7 +17,13 @@ func PortMetrics() (L []*model.MetricValue) {
 		return
 	}
 
-	allListeningPorts, err := nux.ListeningPorts()
+	allTcpListeningPorts, err := nux.TcpPorts()
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	allUdpListeningPorts, err := nux.UdpPorts()
 	if err != nil {
 		log.Println(err)
 		return
@@ -25,7 +31,9 @@ func PortMetrics() (L []*model.MetricValue) {
 
 	for i := 0; i < sz; i++ {
 		tags := fmt.Sprintf("port=%d", reportPorts[i])
-		if slice.ContainsInt64(allListeningPorts, reportPorts[i]) {
+		if slice.ContainsInt64(allTcpListeningPorts, reportPorts[i]) {
+			L = append(L, GaugeValue(g.NET_PORT_LISTEN, 1, tags))
+		} else if slice.ContainsInt64(allUdpListeningPorts, reportPorts[i]) {
 			L = append(L, GaugeValue(g.NET_PORT_LISTEN, 1, tags))
 		} else {
 			L = append(L, GaugeValue(g.NET_PORT_LISTEN, 0, tags))


### PR DESCRIPTION
1. after checking TCP ports, check UDP ports too
1. a better solution may be adding `tcp.port.listen` and `udp.port.listen` to avoid one port listening both TCP and UDP