### PR TITLE
aggreator增加5个运算符（支持集群监控）

### DIFF
--- a/modules/aggregator/cron/computer.go
+++ b/modules/aggregator/cron/computer.go
@@ -1,27 +1,60 @@
 package cron
 
-func compute(operands []string, operators []uint8, hostname string, valMap map[string]float64) (val float64, valid bool) {
+import (
+	"errors"
+	"regexp"
+	"strconv"
+)
+
+func compute(operands []string, operators []string, computeMode string, hostname string, valMap map[string]float64) (val float64, err error) {
+
 	count := len(operands)
 	if count == 0 {
-		return val, false
+		return val, errors.New("counter not found")
 	}
 
 	vals := queryOperands(operands, hostname, valMap)
 	if len(vals) != count {
-		return val, false
+		return val, errors.New("value invalid")
 	}
 
-	val = vals[0]
-
-	for i := 1; i < count; i++ {
-		if operators[i-1] == '+' {
-			val += vals[i]
+	sum := vals[0]
+	for i, v := range vals[1:] {
+		if operators[i] == "+" {
+			sum += v
 		} else {
-			val -= vals[i]
+			sum -= v
 		}
 	}
 
-	return val, true
+	if computeMode != "" {
+		if compareSum(sum, computeMode) {
+			val = 1
+		}
+	} else {
+		val = sum
+	}
+	return val, nil
+}
+
+func compareSum(sum float64, computeMode string) bool {
+
+	regMatch, _ := regexp.Compile(`([><=]+)([\d\.]+)`)
+	match := regMatch.FindStringSubmatch(computeMode)
+
+	mode := match[1]
+	val, _ := strconv.ParseFloat(match[2], 64)
+
+	switch {
+	case mode == ">" && sum > val:
+	case mode == "<" && sum < val:
+	case mode == "=" && sum == val:
+	case mode == ">=" && sum >= val:
+	case mode == "<=" && sum <= val:
+	default:
+		return false
+	}
+	return true
 }
 
 func queryOperands(counters []string, endpoint string, valMap map[string]float64) []float64 {

--- a/modules/aggregator/cron/run_test.go
+++ b/modules/aggregator/cron/run_test.go
@@ -1,0 +1,31 @@
+package cron
+
+import (
+	"testing"
+)
+
+func Test_expressionValid(t *testing.T) {
+
+	expressionMap := map[string]bool{
+		// true
+		"1210":                                     true,
+		"$#":                                       true,
+		"$(cpu.busy)":                              true,
+		"$(cpu.busy)+$(cpu.idle)-$(cpu.nice)":      true,
+		"$(cpu.busy)>=80":                          true,
+		"($(cpu.busy)+$(cpu.idle)-$(cpu.nice))>80": true,
+		"$(qps/module=judge,project=falcon)":       true,
+		"($(cpu.idle)+$(cpu.busy))=100":            true,
+
+		// false
+		"$((cpu.busy)":                     false,
+		"$(cpu.idle)+$(cpu.busy)>40":       false,
+		"($(cpu.idle)+$(cpu.busy)-60)>100": false,
+	}
+
+	for key, val := range expressionMap {
+		if st := expressionValid(key); st != val {
+			t.Errorf("func expressionValid() failure")
+		}
+	}
+}

--- a/modules/aggregator/cron/worker.go
+++ b/modules/aggregator/cron/worker.go
@@ -61,6 +61,10 @@ func deleteNoUseWorker(m map[string]*g.Cluster) {
 func createWorkerIfNeed(m map[string]*g.Cluster) {
 	for key, item := range m {
 		if _, ok := Workers[key]; !ok {
+			if item.Step <= 0 {
+				log.Println("[W] invalid cluster(step <= 0):", item)
+				continue
+			}
 			worker := NewWorker(item)
 			Workers[key] = worker
 			worker.Start()

--- a/modules/aggregator/cron/worker.go
+++ b/modules/aggregator/cron/worker.go
@@ -1,9 +1,10 @@
 package cron
 
 import (
-	"github.com/open-falcon/falcon-plus/modules/aggregator/g"
 	"log"
 	"time"
+
+	"github.com/open-falcon/falcon-plus/modules/aggregator/g"
 )
 
 type Worker struct {


### PR DESCRIPTION
1. commit: fe65951    增加5个操作符，例如 分子 $(cpu.busy)>10，分母 $#，则表示cpu.busy>10的机器数量在整个集群的比例，用于评估集群的健康度或机器利用度
2.  commit: e69ca2f    当集群监控配置中step <= 0时，创建ticker会引发panic，现增加判断