### PR TITLE
fix(agent): ignore mount point when blocks=0

### DIFF
--- a/modules/agent/funcs/dfstat.go
+++ b/modules/agent/funcs/dfstat.go
@@ -43,6 +43,10 @@ func DeviceMetrics() (L []*model.MetricValue) {
 			continue
 		}
 
+		if du.BlocksAll == 0 {
+			continue
+		}
+
 		diskTotal += du.BlocksAll
 		diskUsed += du.BlocksUsed
 

--- a/modules/agent/g/const.go
+++ b/modules/agent/g/const.go
@@ -10,8 +10,9 @@ import (
 // 5.0.0: 支持通过配置控制是否开启/run接口；收集udp流量数据；du某个目录的大小
 // 5.1.0: 同步插件的时候不再使用checksum机制
 // 5.1.1: 修复往多个transfer发送数据的时候crash的问题
+// 5.1.2: ignore mount point when blocks=0
 const (
-	VERSION          = "5.1.1"
+	VERSION          = "5.1.2"
 	COLLECT_INTERVAL = time.Second
 	URL_CHECK_HEALTH = "url.check.health"
 	NET_PORT_LISTEN  = "net.port.listen"


### PR DESCRIPTION
某些挂载点的blocks=0时，UsedPercent = 100.0，使用UserdPercent设置的报警，将会大量误报，该类挂载点可忽略