### PR TITLE
修复aggregator超时的问题

### DIFF
--- a/config/aggregator.json
+++ b/config/aggregator.json
@@ -11,6 +11,8 @@
         "interval": 55
     },
     "api": {
+        "connect_timeout": 500,
+        "request_timeout": 2000,
         "plus_api": "http://127.0.0.1:8080",
         "plus_api_token": "%%PLUS_API_DEFAULT_TOKEN%%",
         "push_api": "http://127.0.0.1:1988/v1/push"


### PR DESCRIPTION
默认超时配置connect_timeout、request_timeout缺失，导致QueryCounterLast()一直超时