### PR TITLE
fix 'equal' error can't bind template to hostgroup

### DIFF
--- a/modules/api/app/controller/host/hostgroup_controller.go
+++ b/modules/api/app/controller/host/hostgroup_controller.go
@@ -258,7 +258,7 @@ func BindTemplateToGroup(c *gin.Context) {
 		TplID: inputs.TplID,
 	}
 	db.Falcon.Where("grp_id = ? and tpl_id = ?", inputs.GrpID, inputs.TplID).Find(&grpTpl)
-	if grpTpl.BindUser == "" {
+	if grpTpl.BindUser != "" {
 		h.JSONR(c, badstatus, errors.New("this binding already existing, reject!"))
 		return
 	}


### PR DESCRIPTION
使用的时候发现这个api不能绑定模板，尝试修复了一下