### PR TITLE
fix DeleteHostGroup bug in hostgroup_controller

### DIFF
--- a/modules/api/app/controller/host/hostgroup_controller.go
+++ b/modules/api/app/controller/host/hostgroup_controller.go
@@ -166,7 +166,7 @@ func DeleteHostGroup(c *gin.Context) {
 			h.JSONR(c, badstatus, dt.Error)
 			return
 		}
-		if hostgroup.CreateUser == user.Name {
+		if hostgroup.CreateUser != user.Name {
 			h.JSONR(c, badstatus, "You don't have permission!")
 			return
 		}


### PR DESCRIPTION
There has logical judgment error in hostgroup_controller.go for func DeleteHostGroup, "hostgroup.CreateUser == user.Name" should be "hostgroup.CreateUser != user.Name"