### PR TITLE
API：修复当grafana graph有多个查询时，因为其中一个未匹配到导致其他正常的查询也无法渲染视图

### DIFF
--- a/modules/api/app/controller/graph/grafana_controller.go
+++ b/modules/api/app/controller/graph/grafana_controller.go
@@ -249,8 +249,8 @@ func GrafanaRender(c *gin.Context) {
 			db.Graph.Table(ecHelp.TableName()).Select("distinct counter").Where(fmt.Sprintf("endpoint_id IN (%s) AND counter regexp '%s'", u.ArrInt64ToStringMust(hostIds), counter)).Scan(&counters)
 		}
 		if len(counters) == 0 {
-			h.JSONR(c, []interface{}{})
-			return
+			// 没有匹配到的继续执行，避免当grafana graph有多个查询时，其他正常的查询也无法渲染视图
+			continue
 		}
 		counterArr := make([]string, len(counters))
 		for indx, c := range counters {


### PR DESCRIPTION
比如在Grafana 的Graph视图中，配置了多个查询语句，当其中有一个查询语句没有匹配到的counter时，代码中应该继续counter并继续执行其他的查询语句，不然会导致其他正常的查询语句也无法渲染视图。这个bug，在使用Grafana的JS动态展示Dashboard时，体验会很差。