### PR TITLE
[agent]通过环境变量来自定义endpoint属性

### DIFF
--- a/modules/agent/g/cfg.go
+++ b/modules/agent/g/cfg.go
@@ -72,6 +72,12 @@ func Hostname() (string, error) {
 		return hostname, nil
 	}
 
+	// use OS ENV ENDPOINT to overwrite hostname
+	if os.Getenv("ENDPOINT") != "" {
+		hostname = os.Getenv("ENDPOINT")
+		return hostname, nil
+	}
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Println("ERROR: os.Hostname() fail", err)


### PR DESCRIPTION
通过环境变量ENDPOINT来自定义 endpoint 主机名属性。


不需要修改系统的主机名，同时保持所有的客户端的 cfg.json 配置文件相同。
在大规模的部署中可以实现所有agent统一配置，同时达到自定义主机名的效果。

客户端的 endpoint 取值优先级为：

1. cfg.json 中的 hostname 属性
2. 系统环境变量 ENDPOINT 
3. 系统的主机名


