### PR TITLE
[agent] support config specific ENV for endpoint

### DIFF
--- a/modules/agent/cfg.example.json
+++ b/modules/agent/cfg.example.json
@@ -1,6 +1,7 @@
 {
     "debug": true,
     "hostname": "",
+    "falcon_endpoint_env": "FALCON_ENDPOINT",
     "ip": "",
     "plugin": {
         "enabled": false,

--- a/modules/agent/g/cfg.go
+++ b/modules/agent/g/cfg.go
@@ -45,6 +45,7 @@ type GlobalConfig struct {
 	Debug         bool              `json:"debug"`
 	Hostname      string            `json:"hostname"`
 	IP            string            `json:"ip"`
+	EndpointEnv   string            `json:"falcon_endpoint_env"`
 	Plugin        *PluginConfig     `json:"plugin"`
 	Heartbeat     *HeartbeatConfig  `json:"heartbeat"`
 	Transfer      *TransferConfig   `json:"transfer"`
@@ -72,8 +73,12 @@ func Hostname() (string, error) {
 		return hostname, nil
 	}
 
-	if os.Getenv("FALCON_ENDPOINT") != "" {
-		hostname = os.Getenv("FALCON_ENDPOINT")
+	EndpointEnv := Config().EndpointEnv
+	if EndpointEnv == "" {
+		EndpointEnv = "FALCON_ENDPOINT"
+	}
+	if os.Getenv(EndpointEnv) != "" {
+		hostname = os.Getenv(EndpointEnv)
 		return hostname, nil
 	}
 


### PR DESCRIPTION
支持从自定义的环境变量名中获取 endpoint，以灵活适配各种运维部署环境。

如果在配置文件中没有 falcon_endpoint_env 的值，则默认读取环境变量 FALCON_ENDPOINT 。