### PR TITLE
优化修复内存指标采集不准的bug：linux内核3.14以后，/proc/meminfo新增了MemAvailable字段

### DIFF
--- a/modules/agent/funcs/meminfo.go
+++ b/modules/agent/funcs/meminfo.go
@@ -14,6 +14,9 @@ func MemMetrics() []*model.MetricValue {
 	}
 
 	memFree := m.MemFree + m.Buffers + m.Cached
+	if m.MemAvailable > 0 {
+		memFree = m.MemAvailable
+	}
 	memUsed := m.MemTotal - memFree
 
 	pmemFree := 0.0

--- a/vendor/github.com/toolkits/nux/meminfo.go
+++ b/vendor/github.com/toolkits/nux/meminfo.go
@@ -19,10 +19,11 @@ type Mem struct {
 	SwapTotal uint64
 	SwapUsed  uint64
 	SwapFree  uint64
+	MemAvailable  uint64
 }
 
 func (this *Mem) String() string {
-	return fmt.Sprintf("<MemTotal:%d, MemFree:%d, Buffers:%d, Cached:%d...>", this.MemTotal, this.MemFree, this.Buffers, this.Cached)
+	return fmt.Sprintf("<MemTotal:%d, MemFree:%d, MemAvailable:%s, Buffers:%d, Cached:%d...>", this.MemTotal, this.MemFree, this.MemAvailable, this.Buffers, this.Cached)
 }
 
 var Multi uint64 = 1024
@@ -34,6 +35,7 @@ var WANT = map[string]struct{}{
 	"MemFree:":   struct{}{},
 	"SwapTotal:": struct{}{},
 	"SwapFree:":  struct{}{},
+	"MemAvailable:":  struct{}{},
 }
 
 func MemInfo() (*Mem, error) {
@@ -77,6 +79,8 @@ func MemInfo() (*Mem, error) {
 				memInfo.SwapTotal = val * Multi
 			case "SwapFree:":
 				memInfo.SwapFree = val * Multi
+			case "MemAvailable:":
+				memInfo.MemAvailable = val * Multi
 			}
 		}
 	}


### PR DESCRIPTION
在3.14的内核上，多了一个新的内存指标：available memory. 它和 free memory是不一样的：

- cat /proc/meminfo:

```
MemTotal:       16268680 kB
MemFree:          349408 kB
MemAvailable:    8366284 kB
Buffers:          534320 kB
Cached:          7107356 kB
SwapCached:            0 kB
Active:         12679016 kB
Inactive:        2380012 kB
Active(anon):    7421048 kB
Inactive(anon):    10428 kB
Active(file):    5257968 kB
Inactive(file):  2369584 kB
Unevictable:           0 kB
Mlocked:               0 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Dirty:             27808 kB
Writeback:             0 kB
AnonPages:       7417360 kB
Mapped:           158928 kB
Shmem:             14116 kB
Slab:             693020 kB
SReclaimable:     642740 kB
SUnreclaim:        50280 kB
KernelStack:       13952 kB
PageTables:        30044 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:     8134340 kB
Committed_AS:   12678180 kB
VmallocTotal:   34359738367 kB
VmallocUsed:       34148 kB
VmallocChunk:   34359699196 kB
HardwareCorrupted:     0 kB
AnonHugePages:   5201920 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
DirectMap4k:      108536 kB
DirectMap2M:    16668672 kB
```

MemAvailable的意义如下：

Many load balancing and workload placing programs check /proc/meminfo to estimate how much free memory is available. They generally do this by adding up "**free**" and "**cached**", **which was fine ten years ago, but is pretty much guaranteed to be wrong today**.

It is wrong because Cached includes memory that is not freeable as page cache, for example shared memory segments, tmpfs, and ramfs, and it does not include reclaimable slab memory, which can take up a large fraction of system memory on mostly idle systems with lots of files.Currently, the amount of memory that is available for a new workload,without pushing the system into swap, can be estimated from MemFree, Active(file), Inactive(file), and SReclaimable, as well as the "low"watermarks from /proc/zoneinfo.However, this may change in the future, and user space really should not be expected to know kernel internals to come up with an estimate for the amount of free memory.It is more convenient to provide such an estimate in /proc/meminfo. If things change in the future, we only have to change it in one place.



**所以如果/proc/meminfo信息中有`MemAvailable`字段，那么系统的内存可用，只需要直接取这个字段的值，这个结果还是准确的。在我们公司生产的机器上，因为忽略这个字段导致的监控指标，内存的使用率误差很大。（使用free命令即可查看准确的内存使用情况）**



代码信息如下：

```c
Signed-off-by: Rik van Riel <riel@redhat.com> 
Reported-by: Erik Mouw <erik.mouw_2@nxp.com> 
Acked-by: Johannes Weiner <hannes@cmpxchg.org> 
Signed-off-by: Andrew Morton <akpm@linux-foundation.org> 
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
Diffstat
-rw-r--r--	Documentation/filesystems/proc.txt	9	
		
-rw-r--r--	fs/proc/meminfo.c	37	
		
2 files changed, 46 insertions, 0 deletions
diff --git a/Documentation/filesystems/proc.txt b/Documentation/filesystems/proc.txt
index 22d89aa3..8533f5f 100644
--- a/Documentation/filesystems/proc.txt
+++ b/Documentation/filesystems/proc.txt
@@ -767,6 +767,7 @@ The "Locked" indicates whether the mapping is locked in memory or not.
MemTotal: 16344972 kB
MemFree: 13634064 kB
+MemAvailable: 14836172 kB
Buffers: 3656 kB
Cached: 1195708 kB
SwapCached: 0 kB
@@ -799,6 +800,14 @@ AnonHugePages: 49152 kB
MemTotal: Total usable ram (i.e. physical ram minus a few reserved
bits and the kernel binary code)
MemFree: The sum of LowFree+HighFree
+MemAvailable: An estimate of how much memory is available for starting new
+ applications, without swapping. Calculated from MemFree,
+ SReclaimable, the size of the file LRU lists, and the low
+ watermarks in each zone.
+ The estimate takes into account that the system needs some
+ page cache to function well, and that not all reclaimable
+ slab will be reclaimable, due to items being in use. The
+ impact of those factors will vary from system to system.
Buffers: Relatively temporary storage for raw disk blocks
shouldn't get tremendously large (20MB or so)
Cached: in-memory cache for files read from the disk (the
diff --git a/fs/proc/meminfo.c b/fs/proc/meminfo.c
index a77d2b2..24270ec 100644
--- a/fs/proc/meminfo.c
+++ b/fs/proc/meminfo.c
@@ -26,7 +26,11 @@ static int meminfo_proc_show(struct seq_file *m, void *v)
unsigned long committed;
struct vmalloc_info vmi;
long cached;
+ long available;
+ unsigned long pagecache;
+ unsigned long wmark_low = 0;
unsigned long pages[NR_LRU_LISTS];
+ struct zone *zone;
int lru;
/*
@@ -47,12 +51,44 @@ static int meminfo_proc_show(struct seq_file *m, void *v)
for (lru = LRU_BASE; lru < NR_LRU_LISTS; lru++)
pages[lru] = global_page_state(NR_LRU_BASE + lru);
+ for_each_zone(zone)
+ wmark_low += zone->watermark[WMARK_LOW];
+
+ /*
+ * Estimate the amount of memory available for userspace allocations,
+ * without causing swapping.
+ *
+ * Free memory cannot be taken below the low watermark, before the
+ * system starts swapping.
+ */
+ available = i.freeram - wmark_low;
+
+ /*
+ * Not all the page cache can be freed, otherwise the system will
+ * start swapping. Assume at least half of the page cache, or the
+ * low watermark worth of cache, needs to stay.
+ */
+ pagecache = pages[LRU_ACTIVE_FILE] + pages[LRU_INACTIVE_FILE];
+ pagecache -= min(pagecache / 2, wmark_low);
+ available += pagecache;
+
+ /*
+ * Part of the reclaimable swap consists of items that are in use,
+ * and cannot be freed. Cap this estimate at the low watermark.
+ */
+ available += global_page_state(NR_SLAB_RECLAIMABLE) -
+ min(global_page_state(NR_SLAB_RECLAIMABLE) / 2, wmark_low);
+
+ if (available < 0)
+ available = 0;
+
/*
* Tagged format, for easy grepping and expansion.
*/
seq_printf(m,
"MemTotal: %8lu kB\n"
"MemFree: %8lu kB\n"
+ "MemAvailable: %8lu kB\n"
"Buffers: %8lu kB\n"
"Cached: %8lu kB\n"
"SwapCached: %8lu kB\n"
@@ -105,6 +141,7 @@ static int meminfo_proc_show(struct seq_file *m, void *v)
,
K(i.totalram),
K(i.freeram),
+ K(available),
K(i.bufferram),
K(cached),
K(total_swapcache_pages()),
```

[https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773)