### PR TITLE
修改了alarm/eventcases api接口，增加了3个过滤条件

### DIFF
--- a/docs/_posts/Alarm/2017-01-01-alarm_eventcases_list.md
+++ b/docs/_posts/Alarm/2017-01-01-alarm_eventcases_list.md
@@ -17,7 +17,10 @@ layout: default
         "limit": 10,
         "process_status": "ignored,unresolved",
         "startTime": 1466956800,
-        "status": "PROBLEM"
+        "status": "PROBLEM",
+        "endpoints": ["agent4"],
+        "strategy_id": 46,
+        "template_id": 126
     }
 ```
 
@@ -46,29 +49,6 @@ layout: default
         "timestamp": "2016-08-01T06:25:00+08:00",
         "tpl_creator": "root",
         "update_at": "2016-08-01T06:25:00+08:00",
-        "user_modified": 0
-    },
-    {
-        "closed_at": null,
-        "closed_note": "",
-        "cond": "95.16331658291456 <= 98",
-        "current_step": 1,
-        "endpoint": "agent5",
-        "expression_id": 0,
-        "func": "avg(#3)",
-        "id": "s_50_6438ac68b30e2712fb8f00d894c46e21",
-        "metric": "cpu.idle",
-        "note": "cpu\u7ecc\u6d2a\u68fd\u934a\u517c\u59e4\u7480\ufffd",
-        "priority": 3,
-        "process_note": 1181,
-        "process_status": "ignored",
-        "status": "PROBLEM",
-        "step": 1,
-        "strategy_id": 50,
-        "template_id": 53,
-        "timestamp": "2016-07-03T16:13:00+08:00",
-        "tpl_creator": "root",
-        "update_at": "2016-07-03T16:13:00+08:00",
         "user_modified": 0
     }
 ]

--- a/modules/api/app/controller/alarm/alarm_events_controller.go
+++ b/modules/api/app/controller/alarm/alarm_events_controller.go
@@ -22,12 +22,16 @@ type APIGetAlarmListsInputs struct {
 	Limit int `json:"limit" form:"limit"`
 	//pagging
 	Page int `json:"page" form:"page"`
+	//endpoints strategy template
+	Endpoints  []string `json:"endpoints" form:"endpoints"`
+	StrategyId int      `json:"strategy_id" form:"strategy_id"`
+	TemplateId int      `json:"template_id" form:"template_id"`
 }
 
 func (input APIGetAlarmListsInputs) checkInputsContain() error {
 	if input.StartTime == 0 && input.EndTime == 0 {
-		if input.EventId == "" {
-			return errors.New("startTime, endTime OR event_id, You have to at least pick one on the request.")
+		if input.EventId == "" && input.Endpoints == nil && input.StrategyId == 0 && input.TemplateId == 0 {
+			return errors.New("startTime, endTime, event_id, endpoints, strategy_id or template_id, You have to at least pick one on the request.")
 		}
 	}
 	return nil
@@ -75,6 +79,18 @@ func (s APIGetAlarmListsInputs) collectFilters() string {
 	}
 	if s.EventId != "" {
 		tmp = append(tmp, fmt.Sprintf("id = '%s'", s.EventId))
+	}
+	if s.Endpoints != nil && len(s.Endpoints) != 0 {
+		for i, ep := range s.Endpoints {
+			s.Endpoints[i] = fmt.Sprintf("'%s'", ep)
+		}
+		tmp = append(tmp, fmt.Sprintf("endpoint in (%s)", strings.Join(s.Endpoints, ", ")))
+	}
+	if s.StrategyId != 0 {
+		tmp = append(tmp, fmt.Sprintf("strategy_id = %d", s.StrategyId))
+	}
+	if s.TemplateId != 0 {
+		tmp = append(tmp, fmt.Sprintf("template_id = %d", s.TemplateId))
 	}
 	filterStrTmp := strings.Join(tmp, " AND ")
 	if filterStrTmp != "" {


### PR DESCRIPTION
通过主机（组）过滤, 会查询出任何发生在endpoints列表里面的报警
"endpoints"":["endpoint1", "endpoint2"]
通过策略查询报警:
"strategy_id": 5
通过模板查询报警:
"templete_id": 5