### PR TITLE
增加grafana Templating对hostgroup的支持

### DIFF
--- a/modules/api/app/controller/graph/grafana_controller.go
+++ b/modules/api/app/controller/graph/grafana_controller.go
@@ -95,9 +95,9 @@ func responseHostsByHostGroup(limit int, hostgroup string) (result []APIGrafanaM
 	for _, grpHost := range grpHosts {
 		hostIDs = append(hostIDs, grpHost.HostID)
 	}
-        if 0 == len(hostIDs) {
+	if 0 == len(hostIDs) {
 		return
-        }
+	}
 	db.Falcon.Table(hostHelp.TableName()).Where("id in (?)", hostIDs).Limit(limit).Scan(&hosts)
 	for _, host := range hosts {
 		result = append(result, APIGrafanaMainQueryOutputs{

--- a/modules/api/app/controller/graph/grafana_controller.go
+++ b/modules/api/app/controller/graph/grafana_controller.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 	cmodel "github.com/open-falcon/falcon-plus/common/model"
 	h "github.com/open-falcon/falcon-plus/modules/api/app/helper"
-	m "github.com/open-falcon/falcon-plus/modules/api/app/model/graph"
 	pm "github.com/open-falcon/falcon-plus/modules/api/app/model/falcon_portal"
+	m "github.com/open-falcon/falcon-plus/modules/api/app/model/graph"
 	u "github.com/open-falcon/falcon-plus/modules/api/app/utils"
 )
 


### PR DESCRIPTION
grafana templating功能：
通过 !HG!前缀查找hostgroup.
通过 !HGH!前缀查找hostgroup下面的host.
