### PR TITLE
change: 优化, 使用"+"代替Sprintf

### DIFF
--- a/modules/graph/g/utils.go
+++ b/modules/graph/g/utils.go
@@ -26,7 +26,8 @@ import (
 // RRDTOOL UTILS
 // 监控数据对应的rrd文件名称
 func RrdFileName(baseDir string, md5 string, dsType string, step int) string {
-	return fmt.Sprintf("%s/%s/%s_%s_%d.rrd", baseDir, md5[0:2], md5, dsType, step)
+	return baseDir + "/" + md5[0:2] + "/" +
+		md5 + "_" + dsType + "_" + strconv.Itoa(step) + ".rrd"
 }
 
 // rrd文件是否存在
@@ -36,7 +37,7 @@ func IsRrdFileExist(filename string) bool {
 
 // 生成rrd缓存数据的key
 func FormRrdCacheKey(md5 string, dsType string, step int) string {
-	return fmt.Sprintf("%s_%s_%d", md5, dsType, step)
+	return md5 + "_" + dsType + "_" + strconv.Itoa(step)
 }
 func SplitRrdCacheKey(ckey string) (md5 string, dsType string, step int, err error) {
 	ckey_slice := strings.Split(ckey, "_")

--- a/modules/graph/g/utils_test.go
+++ b/modules/graph/g/utils_test.go
@@ -1,0 +1,62 @@
+package g
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_RrdFileName(t *testing.T) {
+	if RrdFileName("/basedir", "b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10) !=
+		RrdFileName_orig("/basedir", "b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10) {
+		t.Error("not match with orig func")
+	}
+
+	if RrdFileName("/basedir", "b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10) !=
+		"/basedir/b0/b026324c6904b2a9cb4b88d6d61c81d1_GAUGE_10.rrd" {
+		t.Error("not match")
+	}
+}
+
+func Test_FormRrdCacheKey(t *testing.T) {
+	if FormRrdCacheKey("b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10) !=
+		FormRrdCacheKey_orig("b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10) {
+		t.Error("not match")
+	}
+
+	if FormRrdCacheKey("b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10) !=
+		"b026324c6904b2a9cb4b88d6d61c81d1_GAUGE_10" {
+		t.Error("not match")
+	}
+}
+
+func Benchmark_RrdFileName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		RrdFileName("/basedir", "b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10)
+	}
+}
+
+func Benchmark_RrdFileName_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		RrdFileName_orig("/basedir", "b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10)
+	}
+}
+
+func Benchmark_FormRrdCacheKey(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		FormRrdCacheKey("b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10)
+	}
+}
+
+func Benchmark_FormRrdCacheKey_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		FormRrdCacheKey_orig("b026324c6904b2a9cb4b88d6d61c81d1", "GAUGE", 10)
+	}
+}
+
+func RrdFileName_orig(baseDir string, md5 string, dsType string, step int) string {
+	return fmt.Sprintf("%s/%s/%s_%s_%d.rrd", baseDir, md5[0:2], md5, dsType, step)
+}
+
+func FormRrdCacheKey_orig(md5 string, dsType string, step int) string {
+	return fmt.Sprintf("%s_%s_%d", md5, dsType, step)
+}


### PR DESCRIPTION
Sprintf性能太差, RrdFileName、FormRrdCacheKey均为高频使用的函数。
附benchmark
```
=== RUN   Test_RrdFileName
--- PASS: Test_RrdFileName (0.00s)
=== RUN   Test_FormRrdCacheKey
--- PASS: Test_FormRrdCacheKey (0.00s)
goos: darwin
goarch: amd64
pkg: github.com/open-falcon/falcon-plus/modules/graph/g
Benchmark_RrdFileName-4            	10000000	       127 ns/op
Benchmark_RrdFileName_orig-4       	 3000000	       506 ns/op
Benchmark_FormRrdCacheKey-4        	20000000	        90.4 ns/op
Benchmark_FormRrdCacheKey_orig-4   	 5000000	       324 ns/op
PASS
ok  	github.com/open-falcon/falcon-plus/modules/graph/g	7.282s
```