### PR TITLE
Add AdminLogin API

### DIFF
--- a/docs/_posts/Admin/2017-12-07-admin_login.md
+++ b/docs/_posts/Admin/2017-12-07-admin_login.md
@@ -1,0 +1,29 @@
+---
+category: Admin
+apiurl: '/api/v1/admin/login'
+title: 'Admin Login'
+type: 'POST'
+sample_doc: 'admin.html'
+layout: default
+---
+
+SSO 登入
+
+* [Session](#/authentication) Required
+* `Admin` usage
+
+### Request
+```{
+  "name": "test2",
+}```
+
+### Response
+
+```Status: 200```
+```{
+  "sig": "9d791331c0ea11e690c5001500c6ca5a",
+  "name": "test2",
+  "admin": false
+}```
+
+For errors responses, see the [response status codes documentation](#/response-status-codes).

--- a/docs/doc/admin.html
+++ b/docs/doc/admin.html
@@ -98,11 +98,13 @@
             </div>    
         <ul class="nav nav-pills nav-stacked" role="tablist">
             
-                <li role="presentation"><a href="#0top" role="tab" data-toggle="tab">PUT : /api/v1/admin/change_user_role</a></li>
+                <li role="presentation"><a href="#0top" role="tab" data-toggle="tab">POST : /api/v1/admin/login</a></li>
             
-                <li role="presentation"><a href="#1top" role="tab" data-toggle="tab">PUT : /api/v1/admin/change_user_passwd</a></li>
+                <li role="presentation"><a href="#1top" role="tab" data-toggle="tab">PUT : /api/v1/admin/change_user_role</a></li>
             
-                <li role="presentation"><a href="#2top" role="tab" data-toggle="tab">DELETE : /api/v1/admin/delete_user</a></li>
+                <li role="presentation"><a href="#2top" role="tab" data-toggle="tab">PUT : /api/v1/admin/change_user_passwd</a></li>
+            
+                <li role="presentation"><a href="#3top" role="tab" data-toggle="tab">DELETE : /api/v1/admin/delete_user</a></li>
             
         <ul>
     </div>
@@ -119,40 +121,33 @@
                     </tr>
                     
                     <tr>
+                        <td>Apitoken</td>
+                        <td> {&#34;sig&#34;: &#34;25ae3f6cdb1711e79997005056a6aba2&#34;, &#34;name&#34;: &#34;root&#34;}</td>
+                    </tr>
+                    
+                    <tr>
                         <td>Content-Type</td>
-                        <td>  application/json</td>
-                    </tr>
-                    
-                    <tr>
-                        <td>Cookie</td>
-                        <td>  name=root;sig=dd81ea033c2d11e6a95d0242ac11000c</td>
-                    </tr>
-                    
-                    <tr>
-                        <td>X-Forwarded-For</td>
-                        <td>  </td>
+                        <td>  application/x-www-form-urlencoded</td>
                     </tr>
                     
                 </table>
                 
                 
+                <p> <H4> Post Form </H4> </p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                    
+                    <tr>
+                        <td>name</td>
+                        <td> qfeng</td>
+                    </tr>
+                    
+                </table>
                 
                 
-                <p> <H4> Request Body </H4> </p>
-                <pre id="request-body-0-0" class="prettyprint">{&#34;user_id&#34;: 14, &#34;admin&#34;: &#34;no&#34;}</pre>
-                <script>
-                     
-                    var requestHeader ={"Content-Type":" application/json\r","Cookie":" name=root;sig=dd81ea033c2d11e6a95d0242ac11000c\r","X-Forwarded-For":" "};
-
-                    if (requestHeader["Content-Type"] === "application/json"){
-                        try {
-                            var jsonStr = spaceJson("{\"user_id\": 14, \"admin\": \"no\"}");
-                            document.getElementById('request-body0-0').innerHTML = syntaxHighlight(jsonStr);
-                        } catch (e) {
-                             
-                        }
-                    }
-                </script>
                 
                 <p><h4> Response Code</h4></p>
                 <pre class="prettyprint lang-json">200</pre>
@@ -165,13 +160,33 @@
                     </tr>
                     
                     <tr>
+                        <td>Access-Control-Allow-Credentials</td>
+                        <td> true</td>
+                    </tr>
+                    
+                    <tr>
                         <td>Access-Control-Allow-Headers</td>
-                        <td> Content-Type,Token</td>
+                        <td> Content-Type, Content-Length, Apitoken</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Methods</td>
+                        <td> POST, GET, OPTIONS, PUT, DELETE, UPDATE</td>
                     </tr>
                     
                     <tr>
                         <td>Access-Control-Allow-Origin</td>
                         <td> *</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Expose-Headers</td>
+                        <td> Content-Length</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Max-Age</td>
+                        <td> 86400</td>
                     </tr>
                     
                     <tr>
@@ -183,14 +198,14 @@
                 
                 
                 <p> <H4> Response Body </H4> </p>
-                <pre class="prettyprint" id="response-body-0-0">{&#34;message&#34;:&#34;user role update sccuessful, affect row: 1&#34;}</pre>
+                <pre class="prettyprint" id="response-body-0-0">{&#34;sig&#34;:&#34;05434ff8db0311e7afde005056a6aba2&#34;,&#34;name&#34;:&#34;qfeng&#34;,&#34;admin&#34;:true}</pre>
                 <script>
                      
-                    var responseHeader ={"Access-Control-Allow-Headers":"Content-Type,Token","Access-Control-Allow-Origin":"*","Content-Type":"application/json; charset=utf-8"};
+                    var responseHeader ={"Access-Control-Allow-Credentials":"true","Access-Control-Allow-Headers":"Content-Type, Content-Length, Apitoken","Access-Control-Allow-Methods":"POST, GET, OPTIONS, PUT, DELETE, UPDATE","Access-Control-Allow-Origin":"*","Access-Control-Expose-Headers":"Content-Length","Access-Control-Max-Age":"86400","Content-Type":"application/json; charset=utf-8"};
 
                     if (responseHeader["Content-Type"] === "application/json"){
                         try {
-                            var jsonStr = spaceJson("{\"message\":\"user role update sccuessful, affect row: 1\"}");
+                            var jsonStr = spaceJson("{\"sig\":\"05434ff8db0311e7afde005056a6aba2\",\"name\":\"qfeng\",\"admin\":true}");
                             document.getElementById('response-body-0-0').innerHTML = syntaxHighlight(jsonStr);
                         } catch (e) {
                              
@@ -209,43 +224,36 @@
                     </tr>
                     
                     <tr>
+                        <td>Apitoken</td>
+                        <td> {&#34;sig&#34;: &#34;25ae3f6cdb1711e79997005056a6aba2&#34;, &#34;name&#34;: &#34;root&#34;}</td>
+                    </tr>
+                    
+                    <tr>
                         <td>Content-Type</td>
-                        <td>  application/json</td>
+                        <td>  application/x-www-form-urlencoded</td>
+                    </tr>
+                    
+                </table>
+                
+                
+                <p> <H4> Post Form </H4> </p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
                     </tr>
                     
                     <tr>
-                        <td>Cookie</td>
-                        <td>  name=root;sig=dd81ea033c2d11e6a95d0242ac11000c</td>
-                    </tr>
-                    
-                    <tr>
-                        <td>X-Forwarded-For</td>
-                        <td>  </td>
+                        <td>name</td>
+                        <td> daye</td>
                     </tr>
                     
                 </table>
                 
                 
                 
-                
-                <p> <H4> Request Body </H4> </p>
-                <pre id="request-body-0-1" class="prettyprint">{&#34;user_id&#34;: 14, &#34;admin&#34;: &#34;yes&#34;}</pre>
-                <script>
-                     
-                    var requestHeader ={"Content-Type":" application/json\r","Cookie":" name=root;sig=dd81ea033c2d11e6a95d0242ac11000c\r","X-Forwarded-For":" "};
-
-                    if (requestHeader["Content-Type"] === "application/json"){
-                        try {
-                            var jsonStr = spaceJson("{\"user_id\": 14, \"admin\": \"yes\"}");
-                            document.getElementById('request-body0-1').innerHTML = syntaxHighlight(jsonStr);
-                        } catch (e) {
-                             
-                        }
-                    }
-                </script>
-                
                 <p><h4> Response Code</h4></p>
-                <pre class="prettyprint lang-json">200</pre>
+                <pre class="prettyprint lang-json">400</pre>
                 
                 <p><h4> Response Headers</h4></p>
                 <table class="table table-bordered table-striped">
@@ -255,13 +263,33 @@
                     </tr>
                     
                     <tr>
+                        <td>Access-Control-Allow-Credentials</td>
+                        <td> true</td>
+                    </tr>
+                    
+                    <tr>
                         <td>Access-Control-Allow-Headers</td>
-                        <td> Content-Type,Token</td>
+                        <td> Content-Type, Content-Length, Apitoken</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Methods</td>
+                        <td> POST, GET, OPTIONS, PUT, DELETE, UPDATE</td>
                     </tr>
                     
                     <tr>
                         <td>Access-Control-Allow-Origin</td>
                         <td> *</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Expose-Headers</td>
+                        <td> Content-Length</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Max-Age</td>
+                        <td> 86400</td>
                     </tr>
                     
                     <tr>
@@ -273,15 +301,118 @@
                 
                 
                 <p> <H4> Response Body </H4> </p>
-                <pre class="prettyprint" id="response-body-0-1">{&#34;message&#34;:&#34;user role update sccuessful, affect row: 1&#34;}</pre>
+                <pre class="prettyprint" id="response-body-0-1">{&#34;error&#34;:&#34;no such user&#34;}</pre>
                 <script>
                      
-                    var responseHeader ={"Access-Control-Allow-Headers":"Content-Type,Token","Access-Control-Allow-Origin":"*","Content-Type":"application/json; charset=utf-8"};
+                    var responseHeader ={"Access-Control-Allow-Credentials":"true","Access-Control-Allow-Headers":"Content-Type, Content-Length, Apitoken","Access-Control-Allow-Methods":"POST, GET, OPTIONS, PUT, DELETE, UPDATE","Access-Control-Allow-Origin":"*","Access-Control-Expose-Headers":"Content-Length","Access-Control-Max-Age":"86400","Content-Type":"application/json; charset=utf-8"};
 
                     if (responseHeader["Content-Type"] === "application/json"){
                         try {
-                            var jsonStr = spaceJson("{\"message\":\"user role update sccuessful, affect row: 1\"}");
+                            var jsonStr = spaceJson("{\"error\":\"no such user\"}");
                             document.getElementById('response-body-0-1').innerHTML = syntaxHighlight(jsonStr);
+                        } catch (e) {
+                             
+                        }
+                    }
+                </script>
+                
+                <hr>
+            
+                
+                <p> <H4> Request Headers </H4> </p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                    
+                    <tr>
+                        <td>Apitoken</td>
+                        <td> {&#34;sig&#34;: &#34;05434ff8db0311e7afde005056a6aba2&#34;, &#34;name&#34;: &#34;qfeng&#34;}</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Content-Type</td>
+                        <td>  application/x-www-form-urlencoded</td>
+                    </tr>
+                    
+                </table>
+                
+                
+                <p> <H4> Post Form </H4> </p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                    
+                    <tr>
+                        <td>name</td>
+                        <td> qfeng</td>
+                    </tr>
+                    
+                </table>
+                
+                
+                
+                <p><h4> Response Code</h4></p>
+                <pre class="prettyprint lang-json">400</pre>
+                
+                <p><h4> Response Headers</h4></p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Credentials</td>
+                        <td> true</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Headers</td>
+                        <td> Content-Type, Content-Length, Apitoken</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Methods</td>
+                        <td> POST, GET, OPTIONS, PUT, DELETE, UPDATE</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Origin</td>
+                        <td> *</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Expose-Headers</td>
+                        <td> Content-Length</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Max-Age</td>
+                        <td> 86400</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Content-Type</td>
+                        <td> application/json; charset=utf-8</td>
+                    </tr>
+                    
+                </table>
+                
+                
+                <p> <H4> Response Body </H4> </p>
+                <pre class="prettyprint" id="response-body-0-2">{&#34;error&#34;:&#34;API_USER not admin, no permissions can do this&#34;}</pre>
+                <script>
+                     
+                    var responseHeader ={"Access-Control-Allow-Credentials":"true","Access-Control-Allow-Headers":"Content-Type, Content-Length, Apitoken","Access-Control-Allow-Methods":"POST, GET, OPTIONS, PUT, DELETE, UPDATE","Access-Control-Allow-Origin":"*","Access-Control-Expose-Headers":"Content-Length","Access-Control-Max-Age":"86400","Content-Type":"application/json; charset=utf-8"};
+
+                    if (responseHeader["Content-Type"] === "application/json"){
+                        try {
+                            var jsonStr = spaceJson("{\"error\":\"API_USER not admin, no permissions can do this\"}");
+                            document.getElementById('response-body-0-2').innerHTML = syntaxHighlight(jsonStr);
                         } catch (e) {
                              
                         }
@@ -303,18 +434,13 @@
                     </tr>
                     
                     <tr>
+                        <td>Apitoken</td>
+                        <td> {&#34;sig&#34;: &#34;25ae3f6cdb1711e79997005056a6aba2&#34;, &#34;name&#34;: &#34;root&#34;}</td>
+                    </tr>
+                    
+                    <tr>
                         <td>Content-Type</td>
                         <td>  application/json</td>
-                    </tr>
-                    
-                    <tr>
-                        <td>Cookie</td>
-                        <td>  name=root;sig=dd81ea033c2d11e6a95d0242ac11000c</td>
-                    </tr>
-                    
-                    <tr>
-                        <td>X-Forwarded-For</td>
-                        <td>  </td>
                     </tr>
                     
                 </table>
@@ -323,14 +449,14 @@
                 
                 
                 <p> <H4> Request Body </H4> </p>
-                <pre id="request-body-1-0" class="prettyprint">{&#34;user_id&#34;: 14, &#34;password&#34;: &#34;myhung&#34;}</pre>
+                <pre id="request-body-1-0" class="prettyprint">{&#34;admin&#34;: &#34;yes&#34;, &#34;user_id&#34;: 12}</pre>
                 <script>
                      
-                    var requestHeader ={"Content-Type":" application/json\r","Cookie":" name=root;sig=dd81ea033c2d11e6a95d0242ac11000c\r","X-Forwarded-For":" "};
+                    var requestHeader ={"Apitoken":"{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}","Content-Type":" application/json\r"};
 
                     if (requestHeader["Content-Type"] === "application/json"){
                         try {
-                            var jsonStr = spaceJson("{\"user_id\": 14, \"password\": \"myhung\"}");
+                            var jsonStr = spaceJson("{\"admin\": \"yes\", \"user_id\": 12}");
                             document.getElementById('request-body1-0').innerHTML = syntaxHighlight(jsonStr);
                         } catch (e) {
                              
@@ -349,13 +475,33 @@
                     </tr>
                     
                     <tr>
+                        <td>Access-Control-Allow-Credentials</td>
+                        <td> true</td>
+                    </tr>
+                    
+                    <tr>
                         <td>Access-Control-Allow-Headers</td>
-                        <td> Content-Type,Token</td>
+                        <td> Content-Type, Content-Length, Apitoken</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Methods</td>
+                        <td> POST, GET, OPTIONS, PUT, DELETE, UPDATE</td>
                     </tr>
                     
                     <tr>
                         <td>Access-Control-Allow-Origin</td>
                         <td> *</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Expose-Headers</td>
+                        <td> Content-Length</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Max-Age</td>
+                        <td> 86400</td>
                     </tr>
                     
                     <tr>
@@ -367,15 +513,120 @@
                 
                 
                 <p> <H4> Response Body </H4> </p>
-                <pre class="prettyprint" id="response-body-1-0">{&#34;message&#34;:&#34;password updated!&#34;}</pre>
+                <pre class="prettyprint" id="response-body-1-0">{&#34;message&#34;:&#34;user role update sccuessful, affect row: 0&#34;}</pre>
                 <script>
                      
-                    var responseHeader ={"Access-Control-Allow-Headers":"Content-Type,Token","Access-Control-Allow-Origin":"*","Content-Type":"application/json; charset=utf-8"};
+                    var responseHeader ={"Access-Control-Allow-Credentials":"true","Access-Control-Allow-Headers":"Content-Type, Content-Length, Apitoken","Access-Control-Allow-Methods":"POST, GET, OPTIONS, PUT, DELETE, UPDATE","Access-Control-Allow-Origin":"*","Access-Control-Expose-Headers":"Content-Length","Access-Control-Max-Age":"86400","Content-Type":"application/json; charset=utf-8"};
 
                     if (responseHeader["Content-Type"] === "application/json"){
                         try {
-                            var jsonStr = spaceJson("{\"message\":\"password updated!\"}");
+                            var jsonStr = spaceJson("{\"message\":\"user role update sccuessful, affect row: 0\"}");
                             document.getElementById('response-body-1-0').innerHTML = syntaxHighlight(jsonStr);
+                        } catch (e) {
+                             
+                        }
+                    }
+                </script>
+                
+                <hr>
+            
+                
+                <p> <H4> Request Headers </H4> </p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                    
+                    <tr>
+                        <td>Apitoken</td>
+                        <td> {&#34;sig&#34;: &#34;25ae3f6cdb1711e79997005056a6aba2&#34;, &#34;name&#34;: &#34;root&#34;}</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Content-Type</td>
+                        <td>  application/json</td>
+                    </tr>
+                    
+                </table>
+                
+                
+                
+                
+                <p> <H4> Request Body </H4> </p>
+                <pre id="request-body-1-1" class="prettyprint">{&#34;admin&#34;: &#34;no&#34;, &#34;user_id&#34;: 12}</pre>
+                <script>
+                     
+                    var requestHeader ={"Apitoken":"{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}","Content-Type":" application/json\r"};
+
+                    if (requestHeader["Content-Type"] === "application/json"){
+                        try {
+                            var jsonStr = spaceJson("{\"admin\": \"no\", \"user_id\": 12}");
+                            document.getElementById('request-body1-1').innerHTML = syntaxHighlight(jsonStr);
+                        } catch (e) {
+                             
+                        }
+                    }
+                </script>
+                
+                <p><h4> Response Code</h4></p>
+                <pre class="prettyprint lang-json">200</pre>
+                
+                <p><h4> Response Headers</h4></p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Credentials</td>
+                        <td> true</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Headers</td>
+                        <td> Content-Type, Content-Length, Apitoken</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Methods</td>
+                        <td> POST, GET, OPTIONS, PUT, DELETE, UPDATE</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Origin</td>
+                        <td> *</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Expose-Headers</td>
+                        <td> Content-Length</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Max-Age</td>
+                        <td> 86400</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Content-Type</td>
+                        <td> application/json; charset=utf-8</td>
+                    </tr>
+                    
+                </table>
+                
+                
+                <p> <H4> Response Body </H4> </p>
+                <pre class="prettyprint" id="response-body-1-1">{&#34;message&#34;:&#34;user role update sccuessful, affect row: 1&#34;}</pre>
+                <script>
+                     
+                    var responseHeader ={"Access-Control-Allow-Credentials":"true","Access-Control-Allow-Headers":"Content-Type, Content-Length, Apitoken","Access-Control-Allow-Methods":"POST, GET, OPTIONS, PUT, DELETE, UPDATE","Access-Control-Allow-Origin":"*","Access-Control-Expose-Headers":"Content-Length","Access-Control-Max-Age":"86400","Content-Type":"application/json; charset=utf-8"};
+
+                    if (responseHeader["Content-Type"] === "application/json"){
+                        try {
+                            var jsonStr = spaceJson("{\"message\":\"user role update sccuessful, affect row: 1\"}");
+                            document.getElementById('response-body-1-1').innerHTML = syntaxHighlight(jsonStr);
                         } catch (e) {
                              
                         }
@@ -397,18 +648,13 @@
                     </tr>
                     
                     <tr>
+                        <td>Apitoken</td>
+                        <td> {&#34;sig&#34;: &#34;25ae3f6cdb1711e79997005056a6aba2&#34;, &#34;name&#34;: &#34;root&#34;}</td>
+                    </tr>
+                    
+                    <tr>
                         <td>Content-Type</td>
                         <td>  application/json</td>
-                    </tr>
-                    
-                    <tr>
-                        <td>Cookie</td>
-                        <td>  name=root;sig=dd81ea033c2d11e6a95d0242ac11000c</td>
-                    </tr>
-                    
-                    <tr>
-                        <td>X-Forwarded-For</td>
-                        <td>  </td>
                     </tr>
                     
                 </table>
@@ -417,14 +663,14 @@
                 
                 
                 <p> <H4> Request Body </H4> </p>
-                <pre id="request-body-2-0" class="prettyprint">{&#34;user_id&#34;: 31}</pre>
+                <pre id="request-body-2-0" class="prettyprint">{&#34;password&#34;: &#34;lalala&#34;, &#34;user_id&#34;: 12}</pre>
                 <script>
                      
-                    var requestHeader ={"Content-Type":" application/json\r","Cookie":" name=root;sig=dd81ea033c2d11e6a95d0242ac11000c\r","X-Forwarded-For":" "};
+                    var requestHeader ={"Apitoken":"{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}","Content-Type":" application/json\r"};
 
                     if (requestHeader["Content-Type"] === "application/json"){
                         try {
-                            var jsonStr = spaceJson("{\"user_id\": 31}");
+                            var jsonStr = spaceJson("{\"password\": \"lalala\", \"user_id\": 12}");
                             document.getElementById('request-body2-0').innerHTML = syntaxHighlight(jsonStr);
                         } catch (e) {
                              
@@ -443,13 +689,33 @@
                     </tr>
                     
                     <tr>
+                        <td>Access-Control-Allow-Credentials</td>
+                        <td> true</td>
+                    </tr>
+                    
+                    <tr>
                         <td>Access-Control-Allow-Headers</td>
-                        <td> Content-Type,Token</td>
+                        <td> Content-Type, Content-Length, Apitoken</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Methods</td>
+                        <td> POST, GET, OPTIONS, PUT, DELETE, UPDATE</td>
                     </tr>
                     
                     <tr>
                         <td>Access-Control-Allow-Origin</td>
                         <td> *</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Expose-Headers</td>
+                        <td> Content-Length</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Max-Age</td>
+                        <td> 86400</td>
                     </tr>
                     
                     <tr>
@@ -461,15 +727,124 @@
                 
                 
                 <p> <H4> Response Body </H4> </p>
-                <pre class="prettyprint" id="response-body-2-0">{&#34;message&#34;:&#34;user 31 has been delete, affect row: 1&#34;}</pre>
+                <pre class="prettyprint" id="response-body-2-0">{&#34;message&#34;:&#34;password updated!&#34;}</pre>
                 <script>
                      
-                    var responseHeader ={"Access-Control-Allow-Headers":"Content-Type,Token","Access-Control-Allow-Origin":"*","Content-Type":"application/json; charset=utf-8"};
+                    var responseHeader ={"Access-Control-Allow-Credentials":"true","Access-Control-Allow-Headers":"Content-Type, Content-Length, Apitoken","Access-Control-Allow-Methods":"POST, GET, OPTIONS, PUT, DELETE, UPDATE","Access-Control-Allow-Origin":"*","Access-Control-Expose-Headers":"Content-Length","Access-Control-Max-Age":"86400","Content-Type":"application/json; charset=utf-8"};
 
                     if (responseHeader["Content-Type"] === "application/json"){
                         try {
-                            var jsonStr = spaceJson("{\"message\":\"user 31 has been delete, affect row: 1\"}");
+                            var jsonStr = spaceJson("{\"message\":\"password updated!\"}");
                             document.getElementById('response-body-2-0').innerHTML = syntaxHighlight(jsonStr);
+                        } catch (e) {
+                             
+                        }
+                    }
+                </script>
+                
+                <hr>
+            
+        </div>
+        
+        <div id="3top"  role="tabpanel" class="tab-pane col-md-10">
+            
+                
+                <p> <H4> Request Headers </H4> </p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                    
+                    <tr>
+                        <td>Apitoken</td>
+                        <td> {&#34;sig&#34;: &#34;25ae3f6cdb1711e79997005056a6aba2&#34;, &#34;name&#34;: &#34;root&#34;}</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Content-Type</td>
+                        <td>  application/json</td>
+                    </tr>
+                    
+                </table>
+                
+                
+                
+                
+                <p> <H4> Request Body </H4> </p>
+                <pre id="request-body-3-0" class="prettyprint">{&#34;user_id&#34;: 12}</pre>
+                <script>
+                     
+                    var requestHeader ={"Apitoken":"{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}","Content-Type":" application/json\r"};
+
+                    if (requestHeader["Content-Type"] === "application/json"){
+                        try {
+                            var jsonStr = spaceJson("{\"user_id\": 12}");
+                            document.getElementById('request-body3-0').innerHTML = syntaxHighlight(jsonStr);
+                        } catch (e) {
+                             
+                        }
+                    }
+                </script>
+                
+                <p><h4> Response Code</h4></p>
+                <pre class="prettyprint lang-json">200</pre>
+                
+                <p><h4> Response Headers</h4></p>
+                <table class="table table-bordered table-striped">
+                    <tr>
+                        <th>Key</th>
+                        <th>Value</th>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Credentials</td>
+                        <td> true</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Headers</td>
+                        <td> Content-Type, Content-Length, Apitoken</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Methods</td>
+                        <td> POST, GET, OPTIONS, PUT, DELETE, UPDATE</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Allow-Origin</td>
+                        <td> *</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Expose-Headers</td>
+                        <td> Content-Length</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Access-Control-Max-Age</td>
+                        <td> 86400</td>
+                    </tr>
+                    
+                    <tr>
+                        <td>Content-Type</td>
+                        <td> application/json; charset=utf-8</td>
+                    </tr>
+                    
+                </table>
+                
+                
+                <p> <H4> Response Body </H4> </p>
+                <pre class="prettyprint" id="response-body-3-0">{&#34;message&#34;:&#34;user 12 has been delete, affect row: 1&#34;}</pre>
+                <script>
+                     
+                    var responseHeader ={"Access-Control-Allow-Credentials":"true","Access-Control-Allow-Headers":"Content-Type, Content-Length, Apitoken","Access-Control-Allow-Methods":"POST, GET, OPTIONS, PUT, DELETE, UPDATE","Access-Control-Allow-Origin":"*","Access-Control-Expose-Headers":"Content-Length","Access-Control-Max-Age":"86400","Content-Type":"application/json; charset=utf-8"};
+
+                    if (responseHeader["Content-Type"] === "application/json"){
+                        try {
+                            var jsonStr = spaceJson("{\"message\":\"user 12 has been delete, affect row: 1\"}");
+                            document.getElementById('response-body-3-0').innerHTML = syntaxHighlight(jsonStr);
                         } catch (e) {
                              
                         }

--- a/docs/doc/admin.html.json
+++ b/docs/doc/admin.html.json
@@ -1,106 +1,202 @@
 {
-  "ApiSpecs": [
-    {
-      "HttpVerb": "PUT",
-      "Path": "/api/v1/admin/change_user_role",
-      "Calls": [
+    "ApiSpecs": [
         {
-          "Id": 0,
-          "CurrentPath": "/api/v1/admin/change_user_role",
-          "MethodType": "PUT",
-          "PostForm": null,
-          "RequestHeader": {
-            "Content-Type": " application/json\r",
-            "Cookie": " name=root;sig=dd81ea033c2d11e6a95d0242ac11000c\r",
-            "X-Forwarded-For": " "
-          },
-          "CommonRequestHeaders": null,
-          "ResponseHeader": {
-            "Access-Control-Allow-Headers": "Content-Type,Token",
-            "Access-Control-Allow-Origin": "*",
-            "Content-Type": "application/json; charset=utf-8"
-          },
-          "RequestUrlParams": {},
-          "RequestBody": "{\"user_id\": 14, \"admin\": \"no\"}",
-          "ResponseBody": "{\"message\":\"user role update sccuessful, affect row: 1\"}",
-          "ResponseCode": 200
+            "HttpVerb": "POST",
+            "Path": "/api/v1/admin/login",
+            "Calls": [
+                {
+                    "Id": 0,
+                    "CurrentPath": "/api/v1/admin/login",
+                    "MethodType": "POST",
+                    "PostForm": {
+                        "name": "qfeng"
+                    },
+                    "RequestHeader": {
+                        "Apitoken": "{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}",
+                        "Content-Type": " application/x-www-form-urlencoded\r"
+                    },
+                    "CommonRequestHeaders": null,
+                    "ResponseHeader": {
+                        "Access-Control-Allow-Credentials": "true",
+                        "Access-Control-Allow-Headers": "Content-Type, Content-Length, Apitoken",
+                        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE, UPDATE",
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Expose-Headers": "Content-Length",
+                        "Access-Control-Max-Age": "86400",
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                    "RequestUrlParams": {},
+                    "RequestBody": "",
+                    "ResponseBody": "{\"sig\":\"05434ff8db0311e7afde005056a6aba2\",\"name\":\"qfeng\",\"admin\":true}",
+                    "ResponseCode": 200
+                },
+                {
+                    "Id": 1,
+                    "CurrentPath": "/api/v1/admin/login",
+                    "MethodType": "POST",
+                    "PostForm": {
+                        "name": "daye"
+                    },
+                    "RequestHeader": {
+                        "Apitoken": "{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}",
+                        "Content-Type": " application/x-www-form-urlencoded\r"
+                    },
+                    "CommonRequestHeaders": null,
+                    "ResponseHeader": {
+                        "Access-Control-Allow-Credentials": "true",
+                        "Access-Control-Allow-Headers": "Content-Type, Content-Length, Apitoken",
+                        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE, UPDATE",
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Expose-Headers": "Content-Length",
+                        "Access-Control-Max-Age": "86400",
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                    "RequestUrlParams": {},
+                    "RequestBody": "",
+                    "ResponseBody": "{\"error\":\"no such user\"}",
+                    "ResponseCode": 400
+                },
+                {
+                    "Id": 2,
+                    "CurrentPath": "/api/v1/admin/login",
+                    "MethodType": "POST",
+                    "PostForm": {
+                        "name": "qfeng"
+                    },
+                    "RequestHeader": {
+                        "Apitoken": "{\"sig\": \"05434ff8db0311e7afde005056a6aba2\", \"name\": \"qfeng\"}",
+                        "Content-Type": " application/x-www-form-urlencoded\r"
+                    },
+                    "CommonRequestHeaders": null,
+                    "ResponseHeader": {
+                        "Access-Control-Allow-Credentials": "true",
+                        "Access-Control-Allow-Headers": "Content-Type, Content-Length, Apitoken",
+                        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE, UPDATE",
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Expose-Headers": "Content-Length",
+                        "Access-Control-Max-Age": "86400",
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                    "RequestUrlParams": {},
+                    "RequestBody": "",
+                    "ResponseBody": "{\"error\":\"API_USER not admin, no permissions can do this\"}",
+                    "ResponseCode": 400
+                }
+            ]
         },
         {
-          "Id": 0,
-          "CurrentPath": "/api/v1/admin/change_user_role",
-          "MethodType": "PUT",
-          "PostForm": null,
-          "RequestHeader": {
-            "Content-Type": " application/json\r",
-            "Cookie": " name=root;sig=dd81ea033c2d11e6a95d0242ac11000c\r",
-            "X-Forwarded-For": " "
-          },
-          "CommonRequestHeaders": null,
-          "ResponseHeader": {
-            "Access-Control-Allow-Headers": "Content-Type,Token",
-            "Access-Control-Allow-Origin": "*",
-            "Content-Type": "application/json; charset=utf-8"
-          },
-          "RequestUrlParams": {},
-          "RequestBody": "{\"user_id\": 14, \"admin\": \"yes\"}",
-          "ResponseBody": "{\"message\":\"user role update sccuessful, affect row: 1\"}",
-          "ResponseCode": 200
-        }
-      ]
-    },
-    {
-      "HttpVerb": "PUT",
-      "Path": "/api/v1/admin/change_user_passwd",
-      "Calls": [
+            "HttpVerb": "PUT",
+            "Path": "/api/v1/admin/change_user_role",
+            "Calls": [
+                {
+                    "Id": 3,
+                    "CurrentPath": "/api/v1/admin/change_user_role",
+                    "MethodType": "PUT",
+                    "PostForm": null,
+                    "RequestHeader": {
+                        "Apitoken": "{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}",
+                        "Content-Type": " application/json\r"
+                    },
+                    "CommonRequestHeaders": null,
+                    "ResponseHeader": {
+                        "Access-Control-Allow-Credentials": "true",
+                        "Access-Control-Allow-Headers": "Content-Type, Content-Length, Apitoken",
+                        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE, UPDATE",
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Expose-Headers": "Content-Length",
+                        "Access-Control-Max-Age": "86400",
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                    "RequestUrlParams": {},
+                    "RequestBody": "{\"admin\": \"yes\", \"user_id\": 12}",
+                    "ResponseBody": "{\"message\":\"user role update sccuessful, affect row: 0\"}",
+                    "ResponseCode": 200
+                },
+                {
+                    "Id": 4,
+                    "CurrentPath": "/api/v1/admin/change_user_role",
+                    "MethodType": "PUT",
+                    "PostForm": null,
+                    "RequestHeader": {
+                        "Apitoken": "{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}",
+                        "Content-Type": " application/json\r"
+                    },
+                    "CommonRequestHeaders": null,
+                    "ResponseHeader": {
+                        "Access-Control-Allow-Credentials": "true",
+                        "Access-Control-Allow-Headers": "Content-Type, Content-Length, Apitoken",
+                        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE, UPDATE",
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Expose-Headers": "Content-Length",
+                        "Access-Control-Max-Age": "86400",
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                    "RequestUrlParams": {},
+                    "RequestBody": "{\"admin\": \"no\", \"user_id\": 12}",
+                    "ResponseBody": "{\"message\":\"user role update sccuessful, affect row: 1\"}",
+                    "ResponseCode": 200
+                }
+            ]
+        },
         {
-          "Id": 0,
-          "CurrentPath": "/api/v1/admin/change_user_passwd",
-          "MethodType": "PUT",
-          "PostForm": null,
-          "RequestHeader": {
-            "Content-Type": " application/json\r",
-            "Cookie": " name=root;sig=dd81ea033c2d11e6a95d0242ac11000c\r",
-            "X-Forwarded-For": " "
-          },
-          "CommonRequestHeaders": null,
-          "ResponseHeader": {
-            "Access-Control-Allow-Headers": "Content-Type,Token",
-            "Access-Control-Allow-Origin": "*",
-            "Content-Type": "application/json; charset=utf-8"
-          },
-          "RequestUrlParams": {},
-          "RequestBody": "{\"user_id\": 14, \"password\": \"myhung\"}",
-          "ResponseBody": "{\"message\":\"password updated!\"}",
-          "ResponseCode": 200
-        }
-      ]
-    },
-    {
-      "HttpVerb": "DELETE",
-      "Path": "/api/v1/admin/delete_user",
-      "Calls": [
+            "HttpVerb": "PUT",
+            "Path": "/api/v1/admin/change_user_passwd",
+            "Calls": [
+                {
+                    "Id": 5,
+                    "CurrentPath": "/api/v1/admin/change_user_passwd",
+                    "MethodType": "PUT",
+                    "PostForm": null,
+                    "RequestHeader": {
+                        "Apitoken": "{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}",
+                        "Content-Type": " application/json\r"
+                    },
+                    "CommonRequestHeaders": null,
+                    "ResponseHeader": {
+                        "Access-Control-Allow-Credentials": "true",
+                        "Access-Control-Allow-Headers": "Content-Type, Content-Length, Apitoken",
+                        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE, UPDATE",
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Expose-Headers": "Content-Length",
+                        "Access-Control-Max-Age": "86400",
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                    "RequestUrlParams": {},
+                    "RequestBody": "{\"password\": \"lalala\", \"user_id\": 12}",
+                    "ResponseBody": "{\"message\":\"password updated!\"}",
+                    "ResponseCode": 200
+                }
+            ]
+        },
         {
-          "Id": 1,
-          "CurrentPath": "/api/v1/admin/delete_user",
-          "MethodType": "DELETE",
-          "PostForm": null,
-          "RequestHeader": {
-            "Content-Type": " application/json\r",
-            "Cookie": " name=root;sig=dd81ea033c2d11e6a95d0242ac11000c\r",
-            "X-Forwarded-For": " "
-          },
-          "CommonRequestHeaders": null,
-          "ResponseHeader": {
-            "Access-Control-Allow-Headers": "Content-Type,Token",
-            "Access-Control-Allow-Origin": "*",
-            "Content-Type": "application/json; charset=utf-8"
-          },
-          "RequestUrlParams": {},
-          "RequestBody": "{\"user_id\": 31}",
-          "ResponseBody": "{\"message\":\"user 31 has been delete, affect row: 1\"}",
-          "ResponseCode": 200
+            "HttpVerb": "DELETE",
+            "Path": "/api/v1/admin/delete_user",
+            "Calls": [
+                {
+                    "Id": 6,
+                    "CurrentPath": "/api/v1/admin/delete_user",
+                    "MethodType": "DELETE",
+                    "PostForm": null,
+                    "RequestHeader": {
+                        "Apitoken": "{\"sig\": \"25ae3f6cdb1711e79997005056a6aba2\", \"name\": \"root\"}",
+                        "Content-Type": " application/json\r"
+                    },
+                    "CommonRequestHeaders": null,
+                    "ResponseHeader": {
+                        "Access-Control-Allow-Credentials": "true",
+                        "Access-Control-Allow-Headers": "Content-Type, Content-Length, Apitoken",
+                        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE, UPDATE",
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Expose-Headers": "Content-Length",
+                        "Access-Control-Max-Age": "86400",
+                        "Content-Type": "application/json; charset=utf-8"
+                    },
+                    "RequestUrlParams": {},
+                    "RequestBody": "{\"user_id\": 12}",
+                    "ResponseBody": "{\"message\":\"user 12 has been delete, affect row: 1\"}",
+                    "ResponseCode": 200
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/modules/api/app/controller/uic/session_controller.go
+++ b/modules/api/app/controller/uic/session_controller.go
@@ -30,6 +30,10 @@ type APILoginInput struct {
 	Password string `json:"password"  form:"password" binding:"required"`
 }
 
+type APIAdminLoginInput struct {
+	Name string `json:"name"  form:"name" binding:"required"`
+}
+
 func Login(c *gin.Context) {
 	inputs := APILoginInput{}
 	if err := c.Bind(&inputs); err != nil {
@@ -44,11 +48,59 @@ func Login(c *gin.Context) {
 	}
 	db.Uic.Where(&user).Find(&user)
 	switch {
-	case user.Name == "":
+	case user.ID == 0:
 		h.JSONR(c, badstatus, "no such user")
 		return
 	case user.Passwd != utils.HashIt(password):
 		h.JSONR(c, badstatus, "password error")
+		return
+	}
+	var session uic.Session
+	// response := map[string]string{}
+	s := db.Uic.Table("session").Where("uid = ?", user.ID).Scan(&session)
+	if s.Error != nil && s.Error.Error() != "record not found" {
+		h.JSONR(c, badstatus, s.Error)
+		return
+	} else if session.ID == 0 {
+		session.Sig = utils.GenerateUUID()
+		session.Expired = int(time.Now().Unix()) + 3600*24*30
+		session.Uid = user.ID
+		db.Uic.Create(&session)
+	}
+	log.Debugf("session: %v", session)
+	resp := struct {
+		Sig   string `json:"sig,omitempty"`
+		Name  string `json:"name,omitempty"`
+		Admin bool   `json:"admin"`
+	}{session.Sig, user.Name, user.IsAdmin()}
+	h.JSONR(c, resp)
+	return
+}
+
+func AdminLogin(c *gin.Context) {
+	inputs := APIAdminLoginInput{}
+	if err := c.Bind(&inputs); err != nil {
+		h.JSONR(c, badstatus, "name is blank")
+		return
+	}
+	name := inputs.Name
+
+	user := uic.User{
+		Name: name,
+	}
+	adminuser, err := h.GetUser(c)
+	if err != nil {
+		h.JSONR(c, badstatus, err.Error())
+		return
+	}
+
+	db.Uic.Where(&user).Find(&user)
+	switch {
+	case user.ID == 0:
+		h.JSONR(c, badstatus, "no such user")
+		return
+	case user.Role >= adminuser.Role:
+		h.JSONR(c, badstatus, "API_USER not admin, no permissions can do this")
 		return
 	}
 	var session uic.Session

--- a/modules/api/app/controller/uic/user_routes.go
+++ b/modules/api/app/controller/uic/user_routes.go
@@ -52,6 +52,7 @@ func Routes(r *gin.Engine) {
 	adminapi.PUT("/change_user_passwd", AdminChangePassword)
 	adminapi.PUT("/change_user_profile", AdminChangeUserProfile)
 	adminapi.DELETE("/delete_user", AdminUserDelete)
+	adminapi.POST("/login", AdminLogin)
 
 	//team
 	authapi_team := r.Group("/api/v1")


### PR DESCRIPTION
增加了一个 AdminLogin 的 API
以支持 dashboard 上的的第三方认证。（即 API 直接信任 dashboard 第三方认证的结果）

通过 Apitoken 授权，需要用至少管理员以上的账号起请求 Apitoken

如果请求认证的账号的也是管理员账号，则用于获取 Apitoken 的账号需要是 root

顺带把 no such user 的判断条件改为了
```
case user.ID == 0:
```
因为之前已经声明过了
```
	user := uic.User{
		Name: name,
	}
```
所以通过 `user.Name == ""` 不可能命中条件的