### PR TITLE
调整porttal下host和grp_host一些字段长度

### DIFF
--- a/scripts/mysql/db_schema/2_portal-db-schema.sql
+++ b/scripts/mysql/db_schema/2_portal-db-schema.sql
@@ -11,7 +11,7 @@ SET NAMES utf8;
 DROP TABLE IF EXISTS host;
 CREATE TABLE host
 (
-  id             INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  id             BIGINT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   hostname       VARCHAR(255) NOT NULL DEFAULT '',
   ip             VARCHAR(16)  NOT NULL DEFAULT '',
   agent_version  VARCHAR(16)  NOT NULL DEFAULT '',
@@ -49,8 +49,8 @@ CREATE TABLE `grp` (
 DROP TABLE IF EXISTS grp_host;
 CREATE TABLE grp_host
 (
-  grp_id  INT UNSIGNED NOT NULL,
-  host_id INT UNSIGNED NOT NULL,
+  grp_id  BIGINT(10) UNSIGNED NOT NULL,
+  host_id BIGINT(10) UNSIGNED NOT NULL,
   KEY idx_grp_host_grp_id (grp_id),
   KEY idx_grp_host_host_id (host_id)
 )


### PR DESCRIPTION
host的id字段从INT调整到BIGINT(10)，grp_host的grp_id和host_id都从INT调整到BIGINT(10)，目前有出现这样的情况，就host越来越多的时候会出现加host的时候无法加入，页面一直卡着，而且没有报错，结果发现是三个字段已经超过INT的长度了。