### PR TITLE
update the alarm mail content change newline

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/docs/_posts/2017-01-01-authentication.md
+++ b/docs/_posts/2017-01-01-authentication.md
@@ -10,10 +10,10 @@ layout: default
 ### RequestHeader
 透过RequestHeader 的 Apitoken做验证
 
-```"RequestHeader": {
+"RequestHeader": {
   "Apitoken": "{\"name\":\"root\",\"sig\":\"427d6803b78311e68afd0242ac130006\"}",
   "X-Forwarded-For": " 127.0.0.1"
-}```
+}
 
 ### Response
 

--- a/docs/_posts/2017-01-01-authentication.md
+++ b/docs/_posts/2017-01-01-authentication.md
@@ -10,15 +10,15 @@ layout: default
 ### RequestHeader
 透过RequestHeader 的 Apitoken做验证
 
-"RequestHeader": {
+'''"RequestHeader": {
   "Apitoken": "{\"name\":\"root\",\"sig\":\"427d6803b78311e68afd0242ac130006\"}",
   "X-Forwarded-For": " 127.0.0.1"
-}
+}'''
 
 ### Response
 
 Session 为有效
-   Status: 200
-   {"message":"session is vaild!"}
+'''Status: 200'''
+'''{"message":"session is vaild!"}'''
 
 For errors responses, see the [response status codes documentation](#/response-status-codes).

--- a/docs/_posts/2017-01-01-authentication.md
+++ b/docs/_posts/2017-01-01-authentication.md
@@ -10,15 +10,16 @@ layout: default
 ### RequestHeader
 透过RequestHeader 的 Apitoken做验证
 
-'''"RequestHeader": {
+```
+  "RequestHeader": {
   "Apitoken": "{\"name\":\"root\",\"sig\":\"427d6803b78311e68afd0242ac130006\"}",
   "X-Forwarded-For": " 127.0.0.1"
-}'''
+}```
 
 ### Response
 
 Session 为有效
-'''Status: 200'''
-'''{"message":"session is vaild!"}'''
+```Status: 200```
+```{"message":"session is vaild!"}```
 
 For errors responses, see the [response status codes documentation](#/response-status-codes).

--- a/docs/_posts/2017-01-01-authentication.md
+++ b/docs/_posts/2017-01-01-authentication.md
@@ -10,11 +10,11 @@ layout: default
 ### RequestHeader
 透过RequestHeader 的 Apitoken做验证
 
-   ```
+ ```
   "RequestHeader": {
   "Apitoken": "{\"name\":\"root\",\"sig\":\"427d6803b78311e68afd0242ac130006\"}",
-  "X-Forwarded-For": " 127.0.0.1"
-}```
+  "X-Forwarded-For": " 127.0.0.1"}
+```
 
 ### Response
 

--- a/docs/_posts/2017-01-01-authentication.md
+++ b/docs/_posts/2017-01-01-authentication.md
@@ -18,7 +18,7 @@ layout: default
 ### Response
 
 Session 为有效
-```Status: 200```
-```{"message":"session is vaild!"}```
+   Status: 200
+   {"message":"session is vaild!"}
 
 For errors responses, see the [response status codes documentation](#/response-status-codes).

--- a/docs/_posts/2017-01-01-authentication.md
+++ b/docs/_posts/2017-01-01-authentication.md
@@ -9,6 +9,7 @@ layout: default
 
 ### RequestHeader
 透过RequestHeader 的 Apitoken做验证
+
 ```"RequestHeader": {
   "Apitoken": "{\"name\":\"root\",\"sig\":\"427d6803b78311e68afd0242ac130006\"}",
   "X-Forwarded-For": " 127.0.0.1"

--- a/docs/_posts/2017-01-01-authentication.md
+++ b/docs/_posts/2017-01-01-authentication.md
@@ -10,7 +10,7 @@ layout: default
 ### RequestHeader
 透过RequestHeader 的 Apitoken做验证
 
-```
+   ```
   "RequestHeader": {
   "Apitoken": "{\"name\":\"root\",\"sig\":\"427d6803b78311e68afd0242ac130006\"}",
   "X-Forwarded-For": " 127.0.0.1"

--- a/modules/alarm/cron/combiner.go
+++ b/modules/alarm/cron/combiner.go
@@ -80,7 +80,8 @@ func combineMail() {
 		for i := 0; i < size; i++ {
 			contentArr[i] = arr[i].Content
 		}
-		content := strings.Join(contentArr, "\r\n")
+		//这里邮件聚合的时候把每一条告警通过<br />进行换行，便于看内容！
+		content := strings.Join(contentArr, "\r\n<br />")
 
 		log.Debugf("combined mail subject:%s, content:%s", subject, content)
 		redi.WriteMail([]string{arr[0].Email}, subject, content)


### PR DESCRIPTION
低级别告警邮件聚合以后，出现content的内容没有换行，通过添加<br />来对每条告警进行换行！
原先是这样的邮件内容：
OK P5 Endpoint:root1 Metric:agent.alive Tags: all(#3): 1==-1 Note:open-falocn agent挂了 Max:1, Current:1 Timestamp:2017-12-27 04:29:00 http://127.0.0.1:8081/portal/template/view/1 OK P5 Endpoint:root2 Metric:agent.alive Tags: all(#3): 1==-1 Note:open-falocn agent挂了 Max:1, Current:1 Timestamp:2017-12-27 04:29:00 http://127.0.0.1:8081/portal/template/view/1
现在是这样的邮件内容：
OK P5 Endpoint:root1 Metric:agent.alive Tags: all(#3): 1==-1 Note:open-falocn agent挂了 Max:1, Current:1 Timestamp:2017-12-27 04:29:00 http://127.0.0.1:8081/portal/template/view/1 
OK P5 Endpoint:root2 Metric:agent.alive Tags: all(#3): 1==-1 Note:open-falocn agent挂了 Max:1, Current:1 Timestamp:2017-12-27 04:29:00 http://127.0.0.1:8081/portal/template/view/1