### PR TITLE
fix the bug of the  api's CreateStrategy will duplicate insert the same item !

### DIFF
--- a/modules/api/app/controller/strategy/strategy_controller.go
+++ b/modules/api/app/controller/strategy/strategy_controller.go
@@ -104,6 +104,18 @@ func CreateStrategy(c *gin.Context) {
 		RunEnd:     inputs.RunEnd,
 		TplId:      inputs.TplId,
 	}
+	//在插入数据前先查一下数据中有没有一样的数据避免插入相同的数据。
+	tx := db.Falcon.Begin()
+	strategy_count := []f.Strategy{}
+	if dt := tx.Where(&strategy).Find(&strategy_count); dt.Error != nil {
+		h.JSONR(c, expecstatus, fmt.Sprintf("select strategy got error: %s !", dt.Error))
+		return
+	} else {
+		if len(strategy_count) > 0 {
+			h.JSONR(c, "This stragtegy is already created")
+			return
+		}
+	}
 	dt := db.Falcon.Save(&strategy)
 	if dt.Error != nil {
 		h.JSONR(c, expecstatus, dt.Error)


### PR DESCRIPTION
虽然模板页面中<该模板中的策略列表>中监控项是可以重复添加的，目前api也是可以重复添加的，但是正常情况下重复添加相同的监控项有点多余，如果相同的监控项越来越多对于查询表的速度将会变慢，个人觉得还是需要避免插入相同的数据。