### PR TITLE
fix the bug of mysql5.6 insert into mockcfg

### DIFF
--- a/scripts/mysql/db_schema/2_portal-db-schema.sql
+++ b/scripts/mysql/db_schema/2_portal-db-schema.sql
@@ -180,7 +180,7 @@ CREATE TABLE `mockcfg` (
   `step`     INT(11) UNSIGNED  NOT NULL DEFAULT 60,
   `mock`     DOUBLE  NOT NULL DEFAULT 0  COMMENT 'mocked value when nodata occurs',
   `creator`  VARCHAR(64)  NOT NULL DEFAULT '',
-  `t_create` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
+  `t_create` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uniq_name` (`name`)

--- a/scripts/mysql/db_schema/2_portal-db-schema.sql
+++ b/scripts/mysql/db_schema/2_portal-db-schema.sql
@@ -180,7 +180,7 @@ CREATE TABLE `mockcfg` (
   `step`     INT(11) UNSIGNED  NOT NULL DEFAULT 60,
   `mock`     DOUBLE  NOT NULL DEFAULT 0  COMMENT 'mocked value when nodata occurs',
   `creator`  VARCHAR(64)  NOT NULL DEFAULT '',
-  `t_create` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
+  `t_create` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uniq_name` (`name`)

--- a/scripts/mysql/db_schema/2_portal-db-schema.sql
+++ b/scripts/mysql/db_schema/2_portal-db-schema.sql
@@ -180,7 +180,7 @@ CREATE TABLE `mockcfg` (
   `step`     INT(11) UNSIGNED  NOT NULL DEFAULT 60,
   `mock`     DOUBLE  NOT NULL DEFAULT 0  COMMENT 'mocked value when nodata occurs',
   `creator`  VARCHAR(64)  NOT NULL DEFAULT '',
-  `t_create` DATETIME NOT NULL COMMENT 'create time',
+  `t_create` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uniq_name` (`name`)

--- a/scripts/mysql/db_schema/2_portal-db-schema.sql
+++ b/scripts/mysql/db_schema/2_portal-db-schema.sql
@@ -180,7 +180,7 @@ CREATE TABLE `mockcfg` (
   `step`     INT(11) UNSIGNED  NOT NULL DEFAULT 60,
   `mock`     DOUBLE  NOT NULL DEFAULT 0  COMMENT 'mocked value when nodata occurs',
   `creator`  VARCHAR(64)  NOT NULL DEFAULT '',
-  `t_create` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
+  `t_create` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT  'create time',
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uniq_name` (`name`)


### PR DESCRIPTION
在mysql5.6以后默认开启了严格模式，如果对mockcfg插入数据时候没有给t_create值的话，会报如下错误：
mysql> select version(); 
+-----------+
| version() |
+-----------+
| 5.6.35    |
+-----------+
1 row in set (0.00 sec)
mysql> INSERT INTO `mockcfg` (`name`,`obj`,`obj_type`,`metric`,`tags`,`dstype`,`step`,`mock`,`creator`) VALUES ('football-agent-monitor','hostgroup3','group','agent.alive','','GAUGE','60','-1','admin');
ERROR 1364 (HY000): Field 't_create' doesn't have a default value
要解决这个问题的话，要么修改表字段，要么关闭mysql的严格模式。
该pr是调整了mockcfg的t_create字段格式。