### PR TITLE
[alarm_events_controller]fix AlarmLists paginate api change page to step sql

### DIFF
--- a/modules/api/app/controller/alarm/alarm_events_controller.go
+++ b/modules/api/app/controller/alarm/alarm_events_controller.go
@@ -142,8 +142,8 @@ func AlarmLists(c *gin.Context) {
 		if inputs.Limit >= 50 {
 			inputs.Limit = 50
 		}
-		
-		// if page stands for step page 
+
+		// if page stands for step page
 		// {"page":0} for actual page 1
 		// step = page * limit
 		step := inputs.Page * inputs.Limit

--- a/modules/api/app/controller/alarm/alarm_events_controller.go
+++ b/modules/api/app/controller/alarm/alarm_events_controller.go
@@ -142,7 +142,13 @@ func AlarmLists(c *gin.Context) {
 		if inputs.Limit >= 50 {
 			inputs.Limit = 50
 		}
-		perparedSql = fmt.Sprintf("select * from %s %s  order by timestamp DESC limit %d,%d", f.TableName(), filterCollector, inputs.Page, inputs.Limit)
+		
+		// if page stands for step page 
+		// {"page":0} for actual page 1
+		// step = page * limit
+		step := inputs.Page * inputs.Limit
+
+		perparedSql = fmt.Sprintf("select * from %s %s  order by timestamp DESC limit %d,%d", f.TableName(), filterCollector, step, inputs.Limit)
 	}
 	db.Alarm.Raw(perparedSql).Find(&cevens)
 	h.JSONR(c, cevens)


### PR DESCRIPTION
In `modules/api/app/controller/alarm/alarm_events_controller.go`  paginate should be `step` not `page` in sql.