### PR TITLE
callback returns left_value, that service outside can use it.

### DIFF
--- a/modules/alarm/cron/callback.go
+++ b/modules/alarm/cron/callback.go
@@ -16,9 +16,10 @@ package cron
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"strings"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/open-falcon/falcon-plus/common/model"
 	"github.com/open-falcon/falcon-plus/modules/alarm/api"
@@ -91,6 +92,7 @@ func Callback(event *model.Event, action *api.Action) string {
 	req.Param("tpl_id", fmt.Sprintf("%d", event.TplId()))
 	req.Param("exp_id", fmt.Sprintf("%d", event.ExpressionId()))
 	req.Param("stra_id", fmt.Sprintf("%d", event.StrategyId()))
+	req.Param("left_value", fmt.Sprintf("%d", event.LeftValue))
 	req.Param("tags", tags)
 
 	resp, e := req.String()

--- a/modules/alarm/cron/callback.go
+++ b/modules/alarm/cron/callback.go
@@ -93,7 +93,7 @@ func Callback(event *model.Event, action *api.Action) string {
 	req.Param("tpl_id", fmt.Sprintf("%d", event.TplId()))
 	req.Param("exp_id", fmt.Sprintf("%d", event.ExpressionId()))
 	req.Param("stra_id", fmt.Sprintf("%d", event.StrategyId()))
-	req.Param("left_value", fmt.Sprintf("%s", utils.ReadableFloat(event.LeftValue)))
+	req.Param("left_value", utils.ReadableFloat(event.LeftValue))
 	req.Param("tags", tags)
 
 	resp, e := req.String()

--- a/modules/alarm/cron/callback.go
+++ b/modules/alarm/cron/callback.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/open-falcon/falcon-plus/common/model"
+	"github.com/open-falcon/falcon-plus/common/utils"
 	"github.com/open-falcon/falcon-plus/modules/alarm/api"
 	"github.com/open-falcon/falcon-plus/modules/alarm/redi"
 	"github.com/toolkits/net/httplib"
@@ -92,7 +93,7 @@ func Callback(event *model.Event, action *api.Action) string {
 	req.Param("tpl_id", fmt.Sprintf("%d", event.TplId()))
 	req.Param("exp_id", fmt.Sprintf("%d", event.ExpressionId()))
 	req.Param("stra_id", fmt.Sprintf("%d", event.StrategyId()))
-	req.Param("left_value", fmt.Sprintf("%d", event.LeftValue))
+	req.Param("left_value", fmt.Sprintf("%s", utils.ReadableFloat(event.LeftValue)))
 	req.Param("tags", tags)
 
 	resp, e := req.String()


### PR DESCRIPTION
In the real scene, we need to know the left value of the alarm event. But there is no method to get it.