### PR TITLE
每个用户通过api查询告警只能获取自己的告警

### DIFF
--- a/common/model/event.go
+++ b/common/model/event.go
@@ -59,6 +59,14 @@ func (this *Event) ExpressionId() int {
 	return 0
 }
 
+func (this *Event) Exp() *Expression {
+	if this.Expression != nil {
+		return this.Expression
+	}
+
+	return nil
+}
+
 func (this *Event) StrategyId() int {
 	if this.Strategy != nil {
 		return this.Strategy.Id

--- a/common/model/event.go
+++ b/common/model/event.go
@@ -60,11 +60,7 @@ func (this *Event) ExpressionId() int {
 }
 
 func (this *Event) Exp() *Expression {
-	if this.Expression != nil {
-		return this.Expression
-	}
-
-	return nil
+	return this.Expression
 }
 
 func (this *Event) StrategyId() int {

--- a/common/model/expression.go
+++ b/common/model/expression.go
@@ -31,11 +31,13 @@ type Expression struct {
 	Priority   int               `json:"priority"`
 	Note       string            `json:"note"`
 	ActionId   int               `json:"actionId"`
+	CreateUser string            `json:"createUser"`
+	Pause      int               `json:"pause"`
 }
 
 func (this *Expression) String() string {
 	return fmt.Sprintf(
-		"<Id:%d, Metric:%s, Tags:%v, %s%s%s MaxStep:%d, P%d %s ActionId:%d>",
+		"<Id:%d, Metric:%s, Tags:%v, %s%s%s MaxStep:%d, P%d %s ActionId:%d CreateUser:%s Pause:%d>",
 		this.Id,
 		this.Metric,
 		this.Tags,
@@ -46,6 +48,8 @@ func (this *Expression) String() string {
 		this.Priority,
 		this.Note,
 		this.ActionId,
+		this.CreateUser,
+		this.Pause,
 	)
 }
 

--- a/modules/alarm/model/event/event_operation.go
+++ b/modules/alarm/model/event/event_operation.go
@@ -66,6 +66,13 @@ func InsertEvent(eve *coommonModel.Event) {
 	var errRes error
 	log.Debugf("events: %v", eve)
 	log.Debugf("expression is null: %v", eve.Expression == nil)
+	tpl_creator := ""
+	if eve.Tpl() != nil {
+		tpl_creator = eve.Tpl().Creator
+	}
+	if eve.Exp() != nil {
+		tpl_creator = eve.Exp().CreateUser
+	}
 	if len(event) == 0 {
 		//create cases
 		sqltemplete := `INSERT INTO event_cases (
@@ -87,10 +94,6 @@ func InsertEvent(eve *coommonModel.Event) {
 					template_id
 					) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
 
-		tpl_creator := ""
-		if eve.Tpl() != nil {
-			tpl_creator = eve.Tpl().Creator
-		}
 		sqlLog, errRes = q.Raw(
 			sqltemplete,
 			eve.Id,
@@ -131,11 +134,6 @@ func InsertEvent(eve *coommonModel.Event) {
 		//reopen case
 		if event[0].ProcessStatus == "resolved" || event[0].ProcessStatus == "ignored" {
 			sqltemplete = fmt.Sprintf("%v ,process_status = '%s', process_note = %d", sqltemplete, "unresolved", 0)
-		}
-
-		tpl_creator := ""
-		if eve.Tpl() != nil {
-			tpl_creator = eve.Tpl().Creator
 		}
 		if eve.CurrentStep == 1 {
 			//update start time of cases

--- a/modules/api/cfg.example.json
+++ b/modules/api/cfg.example.json
@@ -26,5 +26,6 @@
 	"skip_auth": false,
 	"default_token": "default-token-used-in-server-side",
 	"gen_doc": false,
-	"gen_doc_path": "doc/module.html"
+	"gen_doc_path": "doc/module.html",
+	"exclusive": false,
 }

--- a/modules/api/cfg.example.json
+++ b/modules/api/cfg.example.json
@@ -27,5 +27,5 @@
 	"default_token": "default-token-used-in-server-side",
 	"gen_doc": false,
 	"gen_doc_path": "doc/module.html",
-	"exclusive": false,
+	"exclusive": false
 }

--- a/modules/api/config/g.go
+++ b/modules/api/config/g.go
@@ -24,7 +24,17 @@ const (
 	VERSION = "0.0.1"
 )
 
+var Exclusive bool
+
 func init() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+}
+
+func setExclusive(val bool) {
+	Exclusive = val
+}
+
+func getExclusive() bool {
+	return Exclusive
 }

--- a/modules/api/main.go
+++ b/modules/api/main.go
@@ -86,6 +86,7 @@ func main() {
 		routes.Use(yaag_gin.Document())
 	}
 	initGraph()
+	config.Exclusive = viper.GetBool("exclusive")
 	//start gin server
 	log.Debugf("will start with port:%v", viper.GetString("web_port"))
 	go controller.StartGin(viper.GetString("web_port"), routes)

--- a/modules/hbs/db/expression.go
+++ b/modules/hbs/db/expression.go
@@ -22,7 +22,7 @@ import (
 )
 
 func QueryExpressions() (ret []*model.Expression, err error) {
-	sql := "select id, expression, func, op, right_value, max_step, priority, note, action_id from expression where action_id>0 and pause=0"
+	sql := "select * from expression where action_id>0 and pause=0"
 	rows, err := DB.Query(sql)
 	if err != nil {
 		log.Println("ERROR:", err)
@@ -43,6 +43,8 @@ func QueryExpressions() (ret []*model.Expression, err error) {
 			&e.Priority,
 			&e.Note,
 			&e.ActionId,
+			&e.CreateUser,
+			&e.Pause,
 		)
 
 		if err != nil {


### PR DESCRIPTION
1. 修改hbs，把expression的creater信息放到结果里，这样judge才能把相
关的信息放入到队列里面
2. 修改alarm，把报警相关的用户放到数据库的tpl_creater里面
3. 修改相关的api， 用户只查询出自己的报警，在alarm的cfg里面增加了
exclusive的配置项，当为true的时候只查询自己的报警，为false的时候和
以前一样，保持兼容。