### PR TITLE
perf: common utils. 包括Md5, PK, PK2, UUID, SortedTags, DictedTagstring等函数

### DIFF
--- a/common/utils/func.go
+++ b/common/utils/func.go
@@ -15,25 +15,69 @@
 package utils
 
 import (
-	"fmt"
+	"bytes"
+	"strconv"
 )
 
 func PK(endpoint, metric string, tags map[string]string) string {
+	ret := bufferPool.Get().(*bytes.Buffer)
+	ret.Reset()
+	defer bufferPool.Put(ret)
+
 	if tags == nil || len(tags) == 0 {
-		return fmt.Sprintf("%s/%s", endpoint, metric)
+		ret.WriteString(endpoint)
+		ret.WriteString("/")
+		ret.WriteString(metric)
+
+		return ret.String()
 	}
-	return fmt.Sprintf("%s/%s/%s", endpoint, metric, SortedTags(tags))
+	ret.WriteString(endpoint)
+	ret.WriteString("/")
+	ret.WriteString(metric)
+	ret.WriteString("/")
+	ret.WriteString(SortedTags(tags))
+	return ret.String()
 }
 
 func PK2(endpoint, counter string) string {
-	return fmt.Sprintf("%s/%s", endpoint, counter)
+	ret := bufferPool.Get().(*bytes.Buffer)
+	ret.Reset()
+	defer bufferPool.Put(ret)
+
+	ret.WriteString(endpoint)
+	ret.WriteString("/")
+	ret.WriteString(counter)
+
+	return ret.String()
 }
 
 func UUID(endpoint, metric string, tags map[string]string, dstype string, step int) string {
+	ret := bufferPool.Get().(*bytes.Buffer)
+	ret.Reset()
+	defer bufferPool.Put(ret)
+
 	if tags == nil || len(tags) == 0 {
-		return fmt.Sprintf("%s/%s/%s/%d", endpoint, metric, dstype, step)
+		ret.WriteString(endpoint)
+		ret.WriteString("/")
+		ret.WriteString(metric)
+		ret.WriteString("/")
+		ret.WriteString(dstype)
+		ret.WriteString("/")
+		ret.WriteString(strconv.Itoa(step))
+
+		return ret.String()
 	}
-	return fmt.Sprintf("%s/%s/%s/%s/%d", endpoint, metric, SortedTags(tags), dstype, step)
+	ret.WriteString(endpoint)
+	ret.WriteString("/")
+	ret.WriteString(metric)
+	ret.WriteString("/")
+	ret.WriteString(SortedTags(tags))
+	ret.WriteString("/")
+	ret.WriteString(dstype)
+	ret.WriteString("/")
+	ret.WriteString(strconv.Itoa(step))
+
+	return ret.String()
 }
 
 func Checksum(endpoint string, metric string, tags map[string]string) string {

--- a/common/utils/func_test.go
+++ b/common/utils/func_test.go
@@ -1,0 +1,123 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+func origPK(endpoint, metric string, tags map[string]string) string {
+	if tags == nil || len(tags) == 0 {
+		return fmt.Sprintf("%s/%s", endpoint, metric)
+	}
+	return fmt.Sprintf("%s/%s/%s", endpoint, metric, SortedTags(tags))
+}
+
+func origPK2(endpoint, counter string) string {
+	return fmt.Sprintf("%s/%s", endpoint, counter)
+}
+
+func origUUID(endpoint, metric string, tags map[string]string, dstype string, step int) string {
+	if tags == nil || len(tags) == 0 {
+		return fmt.Sprintf("%s/%s/%s/%d", endpoint, metric, dstype, step)
+	}
+	return fmt.Sprintf("%s/%s/%s/%s/%d", endpoint, metric, SortedTags(tags), dstype, step)
+}
+
+var pkCase = []struct {
+	endpoint string
+	metric   string
+	tags     map[string]string
+	except   string
+}{
+	{"endpoint1", "metric1", nil, "endpoint1/metric1"},
+	{"endpoint1", "metric1", map[string]string{}, "endpoint1/metric1"},
+	{"endpoint1", "metric1", map[string]string{"k1": "v1", "k2": "v2"}, "endpoint1/metric1/k1=v1,k2=v2"},
+	{"endpoint1", "metric1", map[string]string{"k2": "v2", "k1": "v1"}, "endpoint1/metric1/k1=v1,k2=v2"},
+}
+
+var pk2Case = []struct {
+	endpoint string
+	counter  string
+	except   string
+}{
+	{"endpoint1", "counter1", "endpoint1/counter1"},
+}
+
+var uuidCase = []struct {
+	endpoint string
+	metric   string
+	tags     map[string]string
+	dstype   string
+	step     int
+	except   string
+}{
+	{"endpoint1", "metric1", nil, "ds", 10, "endpoint1/metric1/ds/10"},
+	{"endpoint1", "metric1", map[string]string{}, "ds", 10, "endpoint1/metric1/ds/10"},
+	{"endpoint1", "metric1", map[string]string{"k1": "v1", "k2": "v2"}, "ds", 10, "endpoint1/metric1/k1=v1,k2=v2/ds/10"},
+	{"endpoint1", "metric1", map[string]string{"k2": "v2", "k1": "v1"}, "ds", 10, "endpoint1/metric1/k1=v1,k2=v2/ds/10"},
+}
+
+func Test_PK(t *testing.T) {
+	for _, pk := range pkCase {
+		if PK(pk.endpoint, pk.metric, pk.tags) != origPK(pk.endpoint, pk.metric, pk.tags) || PK(pk.endpoint, pk.metric, pk.tags) != pk.except {
+			t.Error("not except")
+		}
+	}
+}
+
+func Test_PK2(t *testing.T) {
+	for _, pk2 := range pk2Case {
+		if PK2(pk2.endpoint, pk2.counter) != origPK2(pk2.endpoint, pk2.counter) || PK2(pk2.endpoint, pk2.counter) != pk2.except {
+			t.Error("not except")
+		}
+	}
+}
+
+func Test_UUID(t *testing.T) {
+	for _, uuid := range uuidCase {
+		if UUID(uuid.endpoint, uuid.metric, uuid.tags, uuid.dstype, uuid.step) != origUUID(uuid.endpoint, uuid.metric, uuid.tags, uuid.dstype, uuid.step) ||
+			UUID(uuid.endpoint, uuid.metric, uuid.tags, uuid.dstype, uuid.step) != uuid.except {
+			t.Error("not except")
+		}
+	}
+}
+
+var (
+	testTags = map[string]string{"k1": "v1", "k2": "v2"}
+)
+
+func Benchmark_PK(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		PK("endpoint1", "metric1", testTags)
+	}
+}
+
+func Benchmark_PK_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origPK("endpoint1", "metric1", testTags)
+	}
+}
+
+func Benchmark_PK2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		PK2("endpoint1", "counter1")
+	}
+}
+
+func Benchmark_PK2_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origPK2("endpoint1", "counter1")
+	}
+}
+
+func Benchmark_UUID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		UUID("endpoint1", "metric1", testTags, "dt", 10)
+	}
+}
+
+func Benchmark_UUID_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origUUID("endpoint1", "metric1", testTags, "dt", 10)
+	}
+}

--- a/common/utils/md5.go
+++ b/common/utils/md5.go
@@ -16,13 +16,10 @@ package utils
 
 import (
 	"crypto/md5"
-	"fmt"
-	"io"
+	"encoding/hex"
 )
 
 func Md5(raw string) string {
-	h := md5.New()
-	io.WriteString(h, raw)
-
-	return fmt.Sprintf("%x", h.Sum(nil))
+	h := md5.Sum([]byte(raw))
+	return hex.EncodeToString(h[:])
 }

--- a/common/utils/md5_test.go
+++ b/common/utils/md5_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func origMd5(raw string) string {
+	h := md5.New()
+	io.WriteString(h, raw)
+
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func Test_Md5(t *testing.T) {
+	if Md5("1234567890123") != origMd5("1234567890123") {
+		t.Error("not expect")
+	}
+}
+
+func Benchmark_Md5(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Md5("1234567890123")
+	}
+}
+
+func Benchmark_Md5_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origMd5("1234567890123")
+	}
+}

--- a/common/utils/objpool.go
+++ b/common/utils/objpool.go
@@ -1,0 +1,8 @@
+package utils
+
+import (
+	"bytes"
+	"sync"
+)
+
+var bufferPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}

--- a/common/utils/tags_test.go
+++ b/common/utils/tags_test.go
@@ -1,0 +1,248 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+var testCases4map2string = []struct {
+	tags   map[string]string
+	expect string
+}{
+	{map[string]string{"1": "1"}, "1=1"},
+	{map[string]string{"1": "1", "2": "2"}, "1=1,2=2"},
+	{map[string]string{"1": "1", "2": "2", "0": "0"}, "0=0,1=1,2=2"},
+}
+
+var testCases4string2map = []struct {
+	tags   string
+	expect map[string]string
+}{
+	{"1=1", map[string]string{"1": "1"}},
+	{"1=1,2=2", map[string]string{"1": "1", "2": "2"}},
+	{"0=0,1=1,2=2", map[string]string{"1": "1", "2": "2", "0": "0"}},
+	{"0,1=1,2=2", map[string]string{"1": "1", "2": "2"}},
+	{"0=,1=1,2=2", map[string]string{"0": "", "1": "1", "2": "2"}},
+	{"=0,1=1,2=2", map[string]string{"": "0", "1": "1", "2": "2"}},
+	{"0=0, 1=1, 2=2", map[string]string{"0": "0", "1": "1", "2": "2"}},
+}
+
+func origSortedTags(tags map[string]string) string {
+	if tags == nil {
+		return ""
+	}
+
+	size := len(tags)
+
+	if size == 0 {
+		return ""
+	}
+
+	if size == 1 {
+		for k, v := range tags {
+			return fmt.Sprintf("%s=%s", k, v)
+		}
+	}
+
+	keys := make([]string, size)
+	i := 0
+	for k := range tags {
+		keys[i] = k
+		i++
+	}
+
+	sort.Strings(keys)
+
+	ret := make([]string, size)
+	for j, key := range keys {
+		ret[j] = fmt.Sprintf("%s=%s", key, tags[key])
+	}
+
+	return strings.Join(ret, ",")
+}
+
+func origDictedTagstring(s string) map[string]string {
+	if s == "" {
+		return map[string]string{}
+	}
+	s = strings.Replace(s, " ", "", -1)
+
+	tag_dict := make(map[string]string)
+	tags := strings.Split(s, ",")
+	for _, tag := range tags {
+		tag_pair := strings.SplitN(tag, "=", 2)
+		if len(tag_pair) == 2 {
+			tag_dict[tag_pair[0]] = tag_pair[1]
+		}
+	}
+	return tag_dict
+}
+
+func Test_SortedTags(t *testing.T) {
+	for _, testCase := range testCases4map2string {
+		if r := SortedTags(testCase.tags); r != testCase.expect || SortedTags(testCase.tags) != origSortedTags(testCase.tags) {
+			t.Errorf("expect %v, got %v\n", testCase.expect, r)
+		}
+	}
+}
+func Test_DictedTagstring(t *testing.T) {
+	for _, testCase := range testCases4string2map {
+		r := DictedTagstring(testCase.tags)
+		origR := origDictedTagstring(testCase.tags)
+
+		if len(r) != len(testCase.expect) || len(r) != len(origR) {
+			t.FailNow()
+		}
+		for k, v := range r {
+			if expectV, exist := testCase.expect[k]; !exist || v != expectV || v != origR[k] {
+				t.Errorf("expect %v, got %v\n", testCase.expect, r)
+			}
+		}
+	}
+}
+
+func Benchmark_SortedTags_1pair(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SortedTags(map[string]string{"1": "1"})
+	}
+}
+
+func Benchmark_SortedTags_1pair_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origSortedTags(map[string]string{"1": "1"})
+	}
+}
+
+func Benchmark_SortedTags_2pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SortedTags(map[string]string{"1": "1", "2": "2"})
+	}
+}
+
+func Benchmark_SortedTags_2pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origSortedTags(map[string]string{"1": "1", "2": "2"})
+	}
+}
+
+func Benchmark_SortedTags_3pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SortedTags(map[string]string{"1": "1", "2": "2", "3": "3"})
+	}
+}
+
+func Benchmark_SortedTags_3pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origSortedTags(map[string]string{"1": "1", "2": "2", "3": "3"})
+	}
+}
+
+func Benchmark_SortedTags_4pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SortedTags(map[string]string{"1": "1", "2": "2", "3": "3", "4": "4"})
+	}
+}
+
+func Benchmark_SortedTags_4pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origSortedTags(map[string]string{"1": "1", "2": "2", "3": "3", "4": "4"})
+	}
+}
+
+func Benchmark_SortedTags_5pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SortedTags(map[string]string{"1": "1", "2": "2", "3": "3", "4": "4", "5": "5"})
+	}
+}
+
+func Benchmark_SortedTags_5pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origSortedTags(map[string]string{"1": "1", "2": "2", "3": "3", "4": "4", "5": "5"})
+	}
+}
+
+func Benchmark_SortedTags_6pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SortedTags(map[string]string{"1": "1", "2": "2", "3": "3", "4": "4", "5": "5", "0": "0"})
+	}
+}
+
+func Benchmark_SortedTags_6pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origSortedTags(map[string]string{"1": "1", "2": "2", "3": "3", "4": "4", "5": "5", "0": "0"})
+	}
+}
+
+func Benchmark_DictedTagstring_1pair(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		DictedTagstring("1=1")
+	}
+}
+
+func Benchmark_DictedTagstring_1pair_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origDictedTagstring("1=1")
+	}
+}
+
+func Benchmark_DictedTagstring_2pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		DictedTagstring("1=1,2=2")
+	}
+}
+
+func Benchmark_DictedTagstring_2pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origDictedTagstring("1=1,2=2")
+	}
+}
+
+func Benchmark_DictedTagstring_3pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		DictedTagstring("1=1,2=2,3=3")
+	}
+}
+
+func Benchmark_DictedTagstring_3pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origDictedTagstring("1=1,2=2,3=3")
+	}
+}
+
+func Benchmark_DictedTagstring_4pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		DictedTagstring("1=1,2=2,3=3,4=4")
+	}
+}
+
+func Benchmark_DictedTagstring_4pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origDictedTagstring("1=1,2=2,3=3,4=4")
+	}
+}
+
+func Benchmark_DictedTagstring_5pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		DictedTagstring("1=1,2=2,3=3,4=4,5=5")
+	}
+}
+
+func Benchmark_DictedTagstring_5pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origDictedTagstring("1=1,2=2,3=3,4=4,5=5")
+	}
+}
+
+func Benchmark_DictedTagstring_6pairs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		DictedTagstring("1=1,2=2,3=3,4=4,5=5,6=6")
+	}
+}
+
+func Benchmark_DictedTagstring_6pairs_orig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		origDictedTagstring("1=1,2=2,3=3,4=4,5=5,6=6")
+	}
+}


### PR DESCRIPTION
优化效果见如下benchmark结果

```
goos: darwin
goarch: amd64
pkg: github.com/n4mine/falcon-plus/common/utils
Benchmark_PK-4                            	 2000000	       632 ns/op	     112 B/op	       4 allocs/op
Benchmark_PK_orig-4                       	 2000000	       702 ns/op	     160 B/op	       7 allocs/op
Benchmark_PK2-4                           	10000000	       126 ns/op	      32 B/op	       1 allocs/op
Benchmark_PK2_orig-4                      	10000000	       204 ns/op	      64 B/op	       3 allocs/op
Benchmark_UUID-4                          	 2000000	       826 ns/op	     128 B/op	       4 allocs/op
Benchmark_UUID_orig-4                     	 2000000	       894 ns/op	     200 B/op	       9 allocs/op
Benchmark_Md5-4                           	 5000000	       294 ns/op	      64 B/op	       2 allocs/op
Benchmark_Md5_orig-4                      	 3000000	       582 ns/op	     192 B/op	       5 allocs/op
Benchmark_SortedTags_1pair-4              	10000000	       228 ns/op	       3 B/op	       1 allocs/op
Benchmark_SortedTags_1pair_orig-4         	 5000000	       309 ns/op	      35 B/op	       3 allocs/op
Benchmark_SortedTags_2pairs-4             	 3000000	       484 ns/op	      72 B/op	       3 allocs/op
Benchmark_SortedTags_2pairs_orig-4        	 2000000	       878 ns/op	     176 B/op	      10 allocs/op
Benchmark_SortedTags_3pairs-4             	 2000000	       618 ns/op	      96 B/op	       3 allocs/op
Benchmark_SortedTags_3pairs_orig-4        	 1000000	      1236 ns/op	     248 B/op	      13 allocs/op
Benchmark_SortedTags_4pairs-4             	 2000000	       770 ns/op	     112 B/op	       3 allocs/op
Benchmark_SortedTags_4pairs_orig-4        	 1000000	      1607 ns/op	     332 B/op	      17 allocs/op
Benchmark_SortedTags_5pairs-4             	 2000000	       924 ns/op	     144 B/op	       3 allocs/op
Benchmark_SortedTags_5pairs_orig-4        	 1000000	      1878 ns/op	     432 B/op	      20 allocs/op
Benchmark_SortedTags_6pairs-4             	 1000000	      1086 ns/op	     160 B/op	       3 allocs/op
Benchmark_SortedTags_6pairs_orig-4        	 1000000	      2319 ns/op	     499 B/op	      23 allocs/op
Benchmark_DictedTagstring_1pair-4         	 5000000	       259 ns/op	     352 B/op	       3 allocs/op
Benchmark_DictedTagstring_1pair_orig-4    	 5000000	       339 ns/op	     384 B/op	       4 allocs/op
Benchmark_DictedTagstring_2pairs-4        	 5000000	       450 ns/op	     368 B/op	       3 allocs/op
Benchmark_DictedTagstring_2pairs_orig-4   	 3000000	       561 ns/op	     432 B/op	       5 allocs/op
Benchmark_DictedTagstring_3pairs-4        	 3000000	       399 ns/op	     384 B/op	       3 allocs/op
Benchmark_DictedTagstring_3pairs_orig-4   	 2000000	       637 ns/op	     480 B/op	       6 allocs/op
Benchmark_DictedTagstring_4pairs-4        	 3000000	       485 ns/op	     400 B/op	       3 allocs/op
Benchmark_DictedTagstring_4pairs_orig-4   	 2000000	       813 ns/op	     528 B/op	       7 allocs/op
Benchmark_DictedTagstring_5pairs-4        	 3000000	       579 ns/op	     416 B/op	       3 allocs/op
Benchmark_DictedTagstring_5pairs_orig-4   	 1000000	      1026 ns/op	     576 B/op	       8 allocs/op
Benchmark_DictedTagstring_6pairs-4        	 2000000	       664 ns/op	     432 B/op	       3 allocs/op
Benchmark_DictedTagstring_6pairs_orig-4   	 1000000	      1151 ns/op	     624 B/op	       9 allocs/op
PASS
ok  	github.com/n4mine/falcon-plus/common/utils	64.320s
```