### PR TITLE
migrate指标api返回结构化数据

### DIFF
--- a/modules/graph/http/http.go
+++ b/modules/graph/http/http.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/open-falcon/falcon-plus/modules/graph/g"
 	"github.com/open-falcon/falcon-plus/modules/graph/rrdtool"
+	"fmt"
 )
 
 type Dto struct {
@@ -96,9 +97,9 @@ func Start() {
 	}
 
 	router.GET("/api/v2/counter/migrate", func(c *gin.Context) {
-		cnt := rrdtool.GetCounter()
-		log.Debug("migrating counter:", cnt)
-		c.JSON(200, gin.H{"msg": "ok", "counter": cnt})
+		counter := rrdtool.GetCounterV2()
+		log.Debug("migrating counter v2:", fmt.Sprintf("%+v", counter))
+		c.JSON(200, counter)
 	})
 
 	//compatible with open-falcon v0.1

--- a/modules/graph/rrdtool/migrate.go
+++ b/modules/graph/rrdtool/migrate.go
@@ -69,10 +69,36 @@ var (
 	stat_cnt         [STAT_SIZE]uint64
 )
 
+type MigrateCounter struct {
+	FetchSuccess  uint64
+	FetchErr      uint64
+	FetchNotExist uint64
+	SendSuccess   uint64
+	SendErr       uint64
+	QuerySuccess  uint64
+	QueryErr      uint64
+	ConnErr       uint64
+	ConnDial      uint64
+}
+
 func init() {
 	Consistent = consistent.New()
 	Net_task_ch = make(map[string]chan *Net_task_t)
 	clients = make(map[string][]*rpc.Client)
+}
+
+func GetCounterV2() (*MigrateCounter) {
+	return &MigrateCounter{
+		FetchSuccess:  atomic.LoadUint64(&stat_cnt[FETCH_S_SUCCESS]),
+		FetchErr:      atomic.LoadUint64(&stat_cnt[FETCH_S_ERR]),
+		FetchNotExist: atomic.LoadUint64(&stat_cnt[FETCH_S_ISNOTEXIST]),
+		SendSuccess:   atomic.LoadUint64(&stat_cnt[SEND_S_SUCCESS]),
+		SendErr:       atomic.LoadUint64(&stat_cnt[SEND_S_ERR]),
+		QuerySuccess:  atomic.LoadUint64(&stat_cnt[QUERY_S_SUCCESS]),
+		QueryErr:      atomic.LoadUint64(&stat_cnt[QUERY_S_ERR]),
+		ConnErr:       atomic.LoadUint64(&stat_cnt[CONN_S_ERR]),
+		ConnDial:      atomic.LoadUint64(&stat_cnt[CONN_S_DIAL]),
+	}
 }
 
 func GetCounter() (ret string) {


### PR DESCRIPTION
graph扩容时需要关注部分指标情况，例如将统计数据拿出来，通过grafana查看，但是当前版本api返回的是非结构化的数据，适配起来不方便。
当前api返回结果如下：
![image](https://user-images.githubusercontent.com/16460165/39351347-cd8ca994-4a33-11e8-849f-8920a8e5a317.png)
修改后返回结构化数据如下：
![image](https://user-images.githubusercontent.com/16460165/39351403-00b56e32-4a34-11e8-9026-4ec9f71ce77d.png)
