### PR TITLE
查询COUNTER类型数据时，当内存中数据的时间戳不连续时，计算出断点之后的COUNTER数据为NaN，计算错误。

### DIFF
--- a/modules/graph/api/graph.go
+++ b/modules/graph/api/graph.go
@@ -213,9 +213,12 @@ func (this *Graph) Query(param cmodel.GraphQueryParam, resp *cmodel.GraphQueryRe
 		itemIdx := 0
 		if dsType == g.DERIVE || dsType == g.COUNTER {
 			for ts < itemEndTs {
-				if itemIdx < items_size-1 && ts == items[itemIdx].Timestamp &&
-					ts == items[itemIdx+1].Timestamp-int64(step) {
-					val = cmodel.JsonFloat(items[itemIdx+1].Value-items[itemIdx].Value) / cmodel.JsonFloat(step)
+				if itemIdx < items_size-1 && ts == items[itemIdx].Timestamp {
+					if ts == items[itemIdx+1].Timestamp-int64(step) {
+						val = cmodel.JsonFloat(items[itemIdx+1].Value-items[itemIdx].Value) / cmodel.JsonFloat(step)
+					} else {
+						val = cmodel.JsonFloat(math.NaN())
+					}
 					if val < 0 {
 						val = cmodel.JsonFloat(math.NaN())
 					}


### PR DESCRIPTION
查询COUNTER类型数据时，当内存中数据的时间戳不连续时，计算出断点之后的COUNTER数据为NaN，计算错误。
例如：时间序列为（1，2，3，4，6，7，8，9），第4秒以及之后的COUNTER型数据计算值为NaN。