### PR TITLE
修改agent 缓存的lastUpdate 更新策略

### DIFF
--- a/modules/hbs/cache/agents.go
+++ b/modules/hbs/cache/agents.go
@@ -19,10 +19,11 @@ package cache
 // 提供http接口查询机器信息，排查重名机器的时候比较有用
 
 import (
-	"github.com/open-falcon/falcon-plus/common/model"
-	"github.com/open-falcon/falcon-plus/modules/hbs/db"
 	"sync"
 	"time"
+
+	"github.com/open-falcon/falcon-plus/common/model"
+	"github.com/open-falcon/falcon-plus/modules/hbs/db"
 )
 
 type SafeAgents struct {
@@ -48,10 +49,12 @@ func (this *SafeAgents) Put(req *model.AgentReportRequest) {
 		agentInfo.ReportRequest.PluginVersion != req.PluginVersion {
 
 		db.UpdateAgent(val)
-		this.Lock()
-		this.M[req.Hostname] = val
-		this.Unlock()
 	}
+
+	// 更新hbs 时间
+	this.Lock()
+	this.M[req.Hostname] = val
+	this.Unlock()
 }
 
 func (this *SafeAgents) Get(hostname string) (*model.AgentUpdateInfo, bool) {


### PR DESCRIPTION
原来只在AgentVersion，IP, PluginVersion 变化时，才做缓存更新,
这样一个问题的是没有准确记录agent 的心跳时间，从而导致基于lastUpdate
的一些判断没有意义, 比如DeleteStaleAgents 或者基于lasteUpdate
实现的agent.alive 存活状态就无法实现