### PR TITLE
fix:查询策略时候会漏掉设定的run_end时刻如23:59,导致报警策略继承关系丢失

### DIFF
--- a/modules/hbs/db/strategy.go
+++ b/modules/hbs/db/strategy.go
@@ -34,7 +34,7 @@ func QueryStrategies(tpls map[int]*model.Template) (map[int]*model.Strategy, err
 	now := time.Now().Format("15:04")
 	sql := fmt.Sprintf(
 		"select %s from strategy as s where (s.run_begin='' and s.run_end='') "+
-			"or (s.run_begin <= '%s' and s.run_end > '%s')"+
+			"or (s.run_begin <= '%s' and s.run_end >= '%s')"+
 			"or (s.run_begin > s.run_end and !(s.run_begin > '%s' and s.run_end < '%s'))",
 		"s.id, s.metric, s.tags, s.func, s.op, s.right_value, s.max_step, s.priority, s.note, s.tpl_id",
 		now,


### PR DESCRIPTION
fix:查询策略时候会漏掉设定的run_end时刻如23:59,导致报警策略继承关系丢失