### PR TITLE
consume and insert_todb should by async

### DIFF
--- a/modules/alarm/cron/event_reader.go
+++ b/modules/alarm/cron/event_reader.go
@@ -37,7 +37,8 @@ func ReadHighEvent() {
 			time.Sleep(time.Second)
 			continue
 		}
-		consume(event, true)
+		//consume should by async
+		go consume(event, true)
 	}
 }
 
@@ -53,7 +54,8 @@ func ReadLowEvent() {
 			time.Sleep(time.Second)
 			continue
 		}
-		consume(event, false)
+		//consume should by async
+		go consume(event, false)
 	}
 }
 
@@ -87,7 +89,8 @@ func popEvent(queues []string) (*cmodel.Event, error) {
 	log.Debugf("pop event: %s", event.String())
 
 	//insert event into database
-	eventmodel.InsertEvent(&event)
+	// insert todb should by async
+	go eventmodel.InsertEvent(&event)
 	// events no longer saved in memory
 
 	return &event, nil


### PR DESCRIPTION
eventpop 的时候 cosume  insterto_db函数应该加goroutine 加速eventpop的速度，之前有观察到 默认的pop速度 不会超过5条/s,这样event队列一旦堆积，会造成报警延迟