### PR TITLE
ArrStringsToString 字符串数组转换字符串问题

### DIFF
--- a/modules/api/app/utils/to_string.go
+++ b/modules/api/app/utils/to_string.go
@@ -63,9 +63,9 @@ func ArrStringsToString(arr []string) (result string, err error) {
 	result = ""
 	for indx, a := range arr {
 		if indx == 0 {
-			result = fmt.Sprintf("\"%v\"", a)
+			result = fmt.Sprintf("'%v'", a)
 		} else {
-			result = fmt.Sprintf("%v,\"%v\"", result, a)
+			result = fmt.Sprintf("%v,'%v'", result, a)
 		}
 	}
 	if result == "" {


### PR DESCRIPTION
解决grafana调用falcon查询counter接口时，出现获取不到endpoint_id问题。当时grafana调用counter查询接口时，在首先获取endpoint_id时，其中的条件where ( endpoint in (“endpoint”)) 因为ArrStringsToString 函数返回的endpoint格式为： “主机名”，导致查询mysql时出现失败。