### PR TITLE
Fix wrong docker image name in docker/readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -79,7 +79,7 @@ docker run --name falcon-redis -p6379:6379 -d redis:4-alpine3.8
         -e ALARM_DB_USER=root \
         -e ALARM_DB_PASS=test123456 \
         -e ALARM_DB_NAME=alarms \
-        -w /open-falcon/dashboard falcon-dashboard:v0.2.1  \
+        -w /open-falcon/dashboard openfalcon/falcon-dashboard:v0.2.1  \
        './control startfg'
 ```
 


### PR DESCRIPTION
Hi, I just follow the instruction and do the docker installation today.
Then I found there's a little typo here.