### PR TITLE
Fix loop variable captured by func literal

### DIFF
--- a/modules/agent/funcs/du.go
+++ b/modules/agent/funcs/du.go
@@ -38,7 +38,7 @@ func DuMetrics() (L []*model.MetricValue) {
 
 	for _, path := range paths {
 		wg.Add(1)
-		go func(filepath string) {
+		go func(path string) {
 			var err error
 			defer func() {
 				if err != nil {


### PR DESCRIPTION
See https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables.