### PR TITLE
增加多种插件输出格式支持

### DIFF
--- a/modules/agent/g/var.go
+++ b/modules/agent/g/var.go
@@ -96,6 +96,20 @@ func SendToTransfer(metrics []*model.MetricValue) {
 		}
 	}
 
+	now := time.Now().Unix()
+	defaultHostname, _ := Hostname()
+	for _, m := range metrics {
+		if len(m.Endpoint) == 0 {
+			m.Endpoint = defaultHostname
+		}
+		if len(m.Type) == 0 {
+			m.Type = "GAUGE"
+		}
+		if m.Timestamp == 0 {
+			m.Timestamp = now
+		}
+	}
+
 	debug := Config().Debug
 
 	if debug {

--- a/modules/agent/plugins/reader.go
+++ b/modules/agent/plugins/reader.go
@@ -34,6 +34,7 @@ func ListPlugins(relativePath string) map[string]*Plugin {
 	dir := filepath.Join(g.Config().Plugin.Dir, relativePath)
 
 	if !file.IsExist(dir) || file.IsFile(dir) {
+		log.Printf("[WARN] dir %s does not exist\n", dir)
 		return ret
 	}
 

--- a/modules/agent/plugins/scheduler.go
+++ b/modules/agent/plugins/scheduler.go
@@ -23,13 +23,13 @@ import (
 	"syscall"
 	"time"
 
+	"fmt"
 	"github.com/open-falcon/falcon-plus/common/model"
 	"github.com/open-falcon/falcon-plus/modules/agent/g"
 	"github.com/toolkits/file"
 	"github.com/toolkits/sys"
-	"strings"
-	"fmt"
 	"strconv"
+	"strings"
 )
 
 type PluginScheduler struct {

--- a/modules/agent/plugins/scheduler_test.go
+++ b/modules/agent/plugins/scheduler_test.go
@@ -1,0 +1,63 @@
+package plugins
+
+import (
+	"testing"
+	"io/ioutil"
+	"os"
+	"github.com/open-falcon/falcon-plus/modules/agent/g"
+)
+
+func TestProcessOutput(t *testing.T) {
+	cfgFile, err := ioutil.TempFile(os.TempDir(), "falcon-plus.test.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+
+	cfgFile.WriteString(`{ "debug": true}`)
+	cfgFile.Close()
+
+	g.ParseConfig(cfgFile.Name())
+
+	plugin := Plugin{
+		FilePath: "/tmp/test-plugin-file",
+		MTime:    0,
+		Cycle:    60,
+	}
+
+	{
+		dataJson := `[{
+	"metric": "cpu.idle",
+	"tags": "_project=sre,number=1,core=2,test=测试",
+	"value": 301,
+	"timestamp": 1498712372,
+	"judgeType": "G"
+}, {
+	"metric": "cpu.idle",
+	"tags": "_project=sre,number=1,core=2,test=测试",
+	"value": 302,
+	"timestamp": 1498712372,
+	"judgeType": "G"
+}]`
+		metrics := processOutput(&plugin, []byte(dataJson))
+		if len(metrics) != 2 {
+			t.Fatalf("processOutput failed")
+		}
+	}
+
+	{
+		dataLines := `
+metric 102
+metric tag1=v1,tag2=v2 104
+metric tag1=v1,tag2=v2 105 1498712372
+metric 106 1498712372
+metric invalid-value 1498712372
+metric 108 invalid-timestamp
+{"metric": "cpu.idle", "value": 201, "timestamp": 1498712372, "judgeType": "G"}`
+		metrics := processOutput(&plugin, []byte(dataLines))
+		if len(metrics) != 5 {
+			t.Log(metrics)
+			t.Fatalf("processOutput failed")
+		}
+	}
+}

--- a/modules/agent/plugins/scheduler_test.go
+++ b/modules/agent/plugins/scheduler_test.go
@@ -1,10 +1,10 @@
 package plugins
 
 import (
-	"testing"
+	"github.com/open-falcon/falcon-plus/modules/agent/g"
 	"io/ioutil"
 	"os"
-	"github.com/open-falcon/falcon-plus/modules/agent/g"
+	"testing"
 )
 
 func TestProcessOutput(t *testing.T) {


### PR DESCRIPTION
现在的插件只支持输出 json 数组这一种格式，这在用 shell 编写插件时会比较麻烦，所以增加了几种输出格式的支持。新版本插件支持以下的输出格式(2,3 格式可以混用):
1.  插件整体输出 json 数组
2. 插件一行输出一个 json 对象
3. 插件一行输出一个以空格分隔的监控指标, 可选格式:
    1. metric value
    2. metric tag1=v1,tag2=v2 value
    3. metric tag1=v1,tag2=v2 value timestamp
    4. metric value timestamp

更详细的格式示例参见: `modules/agent/plugins/scheduler_test.go`
