### PR TITLE
fix: remove gin debug message on release mode

### DIFF
--- a/modules/graph/http/http.go
+++ b/modules/graph/http/http.go
@@ -37,10 +37,6 @@ var Close_chan, Close_done_chan chan int
 var router *gin.Engine
 
 func init() {
-	router = gin.Default()
-	configCommonRoutes()
-	configProcRoutes()
-	configIndexRoutes()
 	Close_chan = make(chan int, 1)
 	Close_done_chan = make(chan int, 1)
 
@@ -95,6 +91,16 @@ func Start() {
 		log.Println("http.Start warning, not enabled")
 		return
 	}
+
+	if !g.Config().Debug {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
+	router = gin.Default()
+
+	configCommonRoutes()
+	configProcRoutes()
+	configIndexRoutes()
 
 	router.GET("/api/v2/counter/migrate", func(c *gin.Context) {
 		counter := rrdtool.GetCounterV2()

--- a/modules/graph/main.go
+++ b/modules/graph/main.go
@@ -22,8 +22,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/open-falcon/falcon-plus/modules/graph/api"
 	"github.com/open-falcon/falcon-plus/modules/graph/cron"
 	"github.com/open-falcon/falcon-plus/modules/graph/g"
@@ -88,7 +86,6 @@ func main() {
 		g.InitLog("debug")
 	} else {
 		g.InitLog("info")
-		gin.SetMode(gin.ReleaseMode)
 	}
 
 	// init db


### PR DESCRIPTION
**Command**: 
*./graph/bin/falcon-graph -c ./graph/config/cfg.json -v*

**Output**:
```bash
2018/09/15 11:22:35 debug.go:45: [GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /health                   --> github.com/open-falcon/falcon-plus/modules/graph/http.configCommonRoutes.func1 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /api/v2/health            --> github.com/open-falcon/falcon-plus/modules/graph/http.configCommonRoutes.func2 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /api/v2/version           --> github.com/open-falcon/falcon-plus/modules/graph/http.configCommonRoutes.func3 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /api/v2/workdir           --> github.com/open-falcon/falcon-plus/modules/graph/http.configCommonRoutes.func4 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /api/v2/config            --> github.com/open-falcon/falcon-plus/modules/graph/http.configCommonRoutes.func5 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] POST   /api/v2/config/reload     --> github.com/open-falcon/falcon-plus/modules/graph/http.configCommonRoutes.func6 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /api/v2/stats/graph-queue-size --> github.com/open-falcon/falcon-plus/modules/graph/http.configCommonRoutes.func7 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /counter/all              --> github.com/open-falcon/falcon-plus/modules/graph/http.configProcRoutes.func1 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /statistics/all           --> github.com/open-falcon/falcon-plus/modules/graph/http.configProcRoutes.func2 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /index/updateAll          --> github.com/open-falcon/falcon-plus/modules/graph/http.configIndexRoutes.func1 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] GET    /index/updateAll/concurrent --> github.com/open-falcon/falcon-plus/modules/graph/http.configIndexRoutes.func2 (3 handlers)
2018/09/15 11:22:35 debug.go:45: [GIN-debug] POST   /api/v2/index             --> github.com/open-falcon/falcon-plus/modules/graph/http.configIndexRoutes.func3 (3 handlers)
0.5.9
```

**Config**:
```json
{
    "debug": false,
    "http": {
        "enabled": true,
        "listen": "0.0.0.0:6071"
    },
    "rpc": {
        "enabled": true,
        "listen": "0.0.0.0:6070"
    },
    "rrd": {
        "storage": "./data/6070"
    },
    "db": {
        "dsn": "root:xxxxxx@tcp(127.0.0.1:3306)/graph?loc=Local&parseTime=true",
        "maxIdle": 4
    },
    "callTimeout": 5000,
    "migrate": {
            "enabled": false,
            "concurrency": 2,
            "replicas": 500,
            "cluster": {
                    "graph-00" : "127.0.0.1:6070"
            }
    }
}
```