### PR TITLE
fix typo from 'APICrateHostGroup' to 'APICreateHostGroup'

### DIFF
--- a/modules/api/app/controller/host/host_routes.go
+++ b/modules/api/app/controller/host/host_routes.go
@@ -33,7 +33,7 @@ func Routes(r *gin.Engine) {
 	hostr.Use(utils.AuthSessionMidd)
 	//hostgroup
 	hostr.GET("/hostgroup", GetHostGroups)
-	hostr.POST("/hostgroup", CrateHostGroup)
+	hostr.POST("/hostgroup", CreateHostGroup)
 	hostr.POST("/hostgroup/host", BindHostToHostGroup)
 	hostr.PUT("/hostgroup/host", UnBindAHostToHostGroup)
 	hostr.GET("/hostgroup/:host_group", GetHostGroup)

--- a/modules/api/app/controller/host/hostgroup_controller.go
+++ b/modules/api/app/controller/host/hostgroup_controller.go
@@ -57,12 +57,12 @@ func GetHostGroups(c *gin.Context) {
 	return
 }
 
-type APICrateHostGroup struct {
+type APICreateHostGroup struct {
 	Name string `json:"name" binding:"required"`
 }
 
-func CrateHostGroup(c *gin.Context) {
-	var inputs APICrateHostGroup
+func CreateHostGroup(c *gin.Context) {
+	var inputs APICreateHostGroup
 	if err := c.Bind(&inputs); err != nil {
 		h.JSONR(c, badstatus, err)
 		return


### PR DESCRIPTION
fix typo from 'APICrateHostGroup' to 'APICreateHostGroup'