### PR TITLE
correct api url of 'aggregator' creation

### DIFF
--- a/docs/_posts/Aggreator/2017-01-01-aggreator_create.md
+++ b/docs/_posts/Aggreator/2017-01-01-aggreator_create.md
@@ -1,6 +1,6 @@
 ---
 category: Aggreator
-apiurl: '/api/v1/aggregators'
+apiurl: '/api/v1/aggregator'
 title: "Create Aggreator to a HostGroup"
 type: 'POST'
 sample_doc: 'aggreator.html'

--- a/docs/_posts/Strategy/2017-01-01-strategy_create.md
+++ b/docs/_posts/Strategy/2017-01-01-strategy_create.md
@@ -28,4 +28,19 @@ layout: default
 ### Response
 
 ```Status: 200```
-```{"message":"stragtegy created"}```
+```
+{
+  "id": 2,
+  "tpl_id": 221,
+  "tags": "",
+  "run_end": "24:00",
+  "run_begin": "00:00",
+  "right_value": "1",
+  "priority": 1,
+  "op": "==",
+  "note": "this is a test",
+  "metric": "agent.alive",
+  "max_step": 3,
+  "func": "all(#3)"
+}
+```

--- a/modules/api/app/controller/strategy/strategy_controller.go
+++ b/modules/api/app/controller/strategy/strategy_controller.go
@@ -17,11 +17,10 @@ package strategy
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"io/ioutil"
 
 	"github.com/gin-gonic/gin"
 	h "github.com/open-falcon/falcon-plus/modules/api/app/helper"
@@ -109,7 +108,7 @@ func CreateStrategy(c *gin.Context) {
 		h.JSONR(c, expecstatus, dt.Error)
 		return
 	}
-	h.JSONR(c, "stragtegy created")
+	h.JSONR(c, strategy)
 	return
 }
 


### PR DESCRIPTION
According to the route definition, the url to `aggregator` creation should be `/api/v1/aggregator`
```go
//aggreator
hostr.GET("/hostgroup/:host_group/aggregators", GetAggregatorListOfGrp)
hostr.GET("/aggregator/:id", GetAggregator)
hostr.POST("/aggregator", CreateAggregator)
hostr.PUT("/aggregator", UpdateAggregator)
hostr.DELETE("/aggregator/:id", DeleteAggregator)
```