### PR TITLE
[aggregator] Ignore the maintained hostname

### DIFF
--- a/modules/aggregator/sdk/sdk.go
+++ b/modules/aggregator/sdk/sdk.go
@@ -47,7 +47,11 @@ func HostnamesByID(group_id int64) ([]string, error) {
 	}
 
 	hosts := []string{}
+	nowTs := time.Now().Unix()
 	for _, x := range resp.Hosts {
+		if x.MaintainBegin <= nowTs && nowTs <= x.MaintainEnd {
+			continue
+		}
 		hosts = append(hosts, x.Hostname)
 	}
 	return hosts, nil


### PR DESCRIPTION
Ignore the maintained hostname

某些服务器因为故障原因会进行维护，而进行维护的节点不运行业务，因此不需要将该服务器纳入集群视角。