### PR TITLE
使agent模块插件支持传参

### DIFF
--- a/modules/api/app/controller/alarm/alarm_events_controller.go
+++ b/modules/api/app/controller/alarm/alarm_events_controller.go
@@ -202,7 +202,7 @@ func EventsGet(c *gin.Context) {
 	if inputs.Limit == 0 || inputs.Limit >= 50 {
 		inputs.Limit = 50
 	}
-	perparedSql := fmt.Sprintf("select id, event_caseId, cond, status, timestamp from %s %s order by timestamp DESC limit %d,%d", f.TableName(), filterCollector, inputs.Page, inputs.Limit)
+	perparedSql := fmt.Sprintf("select id, step, event_caseId, cond, status, timestamp from %s %s order by timestamp DESC limit %d,%d", f.TableName(), filterCollector, inputs.Page, inputs.Limit)
 	db.Alarm.Raw(perparedSql).Scan(&evens)
 	h.JSONR(c, evens)
 }


### PR DESCRIPTION
在官方sys/ntp格式的插件配置基础上，同时支持sys/ntp(arg1,arg2)格式的插件配置，参数以括号包裹传递到agent端