### PR TITLE
fix agent funcs calculate meminfo problem

### DIFF
--- a/modules/agent/funcs/meminfo.go
+++ b/modules/agent/funcs/meminfo.go
@@ -28,6 +28,9 @@ func MemMetrics() []*model.MetricValue {
 	}
 
 	memFree := m.MemFree + m.Buffers + m.Cached
+	if m.MemAvailable > 0 {
+		memFree = m.MemAvailable
+	}
 	memUsed := m.MemTotal - memFree
 
 	pmemFree := 0.0


### PR DESCRIPTION
修正在centos等版本下对内存计算存在较大偏差的问题：
1、第三方库在计算memfree时未考虑由于版本问题MemAvailable字段是否会计算，例如在centos6.3内存字段中就没有MemAvailable，而在cent0s7以上版本为了更好的衡量进程间通信，加入了MemAvailable字段
2、该修改在centos、ubuntu等测试均与实际值一致