### PR TITLE
 gateway -> transfer AES encryption

### DIFF
--- a/common/encrypt/encrypt.go
+++ b/common/encrypt/encrypt.go
@@ -17,13 +17,13 @@ func Encode(src interface{}) []byte  {
 }
 
 // byte -> struct
-func Decode(from []byte, to interface{})  {
+func Decode(from []byte, to interface{}) {
 	dec := gob.NewDecoder(bytes.NewBuffer(from))
 	dec.Decode(to)
 }
 
 func PKCS5Padding(ciphertext []byte, blockSize int) []byte {
-	padding := blockSize - len(ciphertext) % blockSize
+	padding := blockSize - len(ciphertext)%blockSize
 	padText := bytes.Repeat([]byte{byte(padding)}, padding)
 	return append(ciphertext, padText...)
 }

--- a/common/encrypt/encrypt.go
+++ b/common/encrypt/encrypt.go
@@ -1,0 +1,63 @@
+package encrypt
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/gob"
+)
+
+
+// struct -> byte
+func Encode(src interface{}) []byte  {
+	buf := new(bytes.Buffer)
+	enc := gob.NewEncoder(buf)
+	enc.Encode(src)
+	return buf.Bytes()
+}
+
+// byte -> struct
+func Decode(from []byte, to interface{})  {
+	dec := gob.NewDecoder(bytes.NewBuffer(from))
+	dec.Decode(to)
+}
+
+func PKCS5Padding(ciphertext []byte, blockSize int) []byte {
+	padding := blockSize - len(ciphertext) % blockSize
+	padText := bytes.Repeat([]byte{byte(padding)}, padding)
+	return append(ciphertext, padText...)
+}
+
+func PKCS5UnPadding(origData []byte) []byte {
+	length := len(origData)
+	unPadding := int(origData[length-1])
+	return origData[:(length - unPadding)]
+}
+
+func Encrypt(origData, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	blockSize := block.BlockSize()
+	origData = PKCS5Padding(origData, blockSize)
+	blockMode := cipher.NewCBCEncrypter(block, key[:blockSize])
+	encrypted := make([]byte, len(origData))
+
+	blockMode.CryptBlocks(encrypted, origData)
+	return encrypted, nil
+}
+
+func Decrypt(encrypted, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	blockSize := block.BlockSize()
+	blockMode := cipher.NewCBCDecrypter(block, key[:blockSize])
+	origData := make([]byte, len(encrypted))
+
+	blockMode.CryptBlocks(origData, encrypted)
+	origData = PKCS5UnPadding(origData)
+	return origData, nil
+}

--- a/common/encrypt/encrypt.go
+++ b/common/encrypt/encrypt.go
@@ -22,10 +22,10 @@ func Decode(from []byte, to interface{}) {
 	dec.Decode(to)
 }
 
-func PKCS5Padding(ciphertext []byte, blockSize int) []byte {
-	padding := blockSize - len(ciphertext)%blockSize
+func PKCS5Padding(cipherText []byte, blockSize int) []byte {
+	padding := blockSize - len(cipherText)%blockSize
 	padText := bytes.Repeat([]byte{byte(padding)}, padding)
-	return append(ciphertext, padText...)
+	return append(cipherText, padText...)
 }
 
 func PKCS5UnPadding(origData []byte) []byte {

--- a/common/model/encrypt.go
+++ b/common/model/encrypt.go
@@ -1,0 +1,5 @@
+package model
+
+type Encrypt struct {
+	Byte []byte
+}

--- a/common/model/metric.go
+++ b/common/model/metric.go
@@ -28,6 +28,7 @@ type MetricValue struct {
 	Type      string      `json:"counterType"`
 	Tags      string      `json:"tags"`
 	Timestamp int64       `json:"timestamp"`
+	Byte      []byte      `json:"byte"` // for aes
 }
 
 func (this *MetricValue) String() string {

--- a/modules/gateway/cfg.example.json
+++ b/modules/gateway/cfg.example.json
@@ -4,6 +4,7 @@
         "enabled": true,
         "listen": "0.0.0.0:6060"
     },
+    "aesKey": "",
     "rpc": {
         "enabled": true,
         "listen": "0.0.0.0:8433"

--- a/modules/gateway/g/cfg.go
+++ b/modules/gateway/g/cfg.go
@@ -55,6 +55,7 @@ type GlobalConfig struct {
 	Rpc      *RpcConfig      `json:"rpc"`
 	Socket   *SocketConfig   `json:"socket"`
 	Transfer *TransferConfig `json:"transfer"`
+	AesKey   string          `json:"aesKey"`
 }
 
 var (

--- a/modules/gateway/sender/send_tasks.go
+++ b/modules/gateway/sender/send_tasks.go
@@ -85,7 +85,7 @@ func forward2TransferTask(Q *nlist.SafeListLimited, concurrent int32) {
 
 					pfc.Counter(host, 1)
 
-					if len(aesKey) > 16 {
+					if len(aesKey) == 16 {
 						encrypted, _ := encrypt.Encrypt(encrypt.Encode(transItems), []byte(g.Config().AesKey))
 						err = SenderConnPools.Call(addr, "Transfer.Update", []cmodel.Encrypt{{Byte: encrypted}}, resp)
 					} else {

--- a/modules/gateway/sender/send_tasks.go
+++ b/modules/gateway/sender/send_tasks.go
@@ -16,6 +16,7 @@ package sender
 
 import (
 	log "github.com/Sirupsen/logrus"
+	"github.com/open-falcon/falcon-plus/common/encrypt"
 	"math/rand"
 	"time"
 
@@ -67,6 +68,7 @@ func forward2TransferTask(Q *nlist.SafeListLimited, concurrent int32) {
 			// 随机遍历transfer列表，直到数据发送成功 或者 遍历完;随机遍历，可以缓解慢transfer
 			resp := &cmodel.TransferResponse{}
 			sendOk := false
+			aesKey := g.Config().AesKey
 
 			for j := 0; j < retry && !sendOk; j++ {
 				rint := rand.Int()
@@ -82,7 +84,14 @@ func forward2TransferTask(Q *nlist.SafeListLimited, concurrent int32) {
 					}
 
 					pfc.Counter(host, 1)
-					err = SenderConnPools.Call(addr, "Transfer.Update", transItems, resp)
+
+					if len(aesKey) > 16 {
+						encrypted, _ := encrypt.Encrypt(encrypt.Encode(transItems), []byte(g.Config().AesKey))
+						err = SenderConnPools.Call(addr, "Transfer.Update", []cmodel.Encrypt{{Byte: encrypted}}, resp)
+					} else {
+						err = SenderConnPools.Call(addr, "Transfer.Update", transItems, resp)
+					}
+
 					pfc.Counter(host, -1)
 
 					if err == nil {

--- a/modules/transfer/cfg.example.json
+++ b/modules/transfer/cfg.example.json
@@ -5,6 +5,7 @@
         "enabled": true,
         "listen": "0.0.0.0:6060"
     },
+    "aesKey": "",
     "rpc": {
         "enabled": true,
         "listen": "0.0.0.0:8433"

--- a/modules/transfer/g/cfg.go
+++ b/modules/transfer/g/cfg.go
@@ -82,6 +82,7 @@ type GlobalConfig struct {
 	Judge   *JudgeConfig  `json:"judge"`
 	Graph   *GraphConfig  `json:"graph"`
 	Tsdb    *TsdbConfig   `json:"tsdb"`
+	AesKey  string        `json:"aesKey"`
 }
 
 var (

--- a/modules/transfer/receiver/rpc/rpc_transfer.go
+++ b/modules/transfer/receiver/rpc/rpc_transfer.go
@@ -16,6 +16,7 @@ package rpc
 
 import (
 	"fmt"
+	"github.com/open-falcon/falcon-plus/common/encrypt"
 	cmodel "github.com/open-falcon/falcon-plus/common/model"
 	cutils "github.com/open-falcon/falcon-plus/common/utils"
 	"github.com/open-falcon/falcon-plus/modules/transfer/g"
@@ -55,6 +56,11 @@ func (t *Transfer) Update(args []*cmodel.MetricValue, reply *cmodel.TransferResp
 func RecvMetricValues(args []*cmodel.MetricValue, reply *cmodel.TransferResponse, from string) error {
 	start := time.Now()
 	reply.Invalid = 0
+
+	if len(args) > 0 && len(args[0].Byte) > 0 {
+		dec, _ := encrypt.Decrypt(args[0].Byte, []byte(g.Config().AesKey))
+		encrypt.Decode(dec, &args)
+	}
 
 	items := []*cmodel.MetaData{}
 	for _, v := range args {


### PR DESCRIPTION
gateway传输到transfer添加 AES加密

rpc框架
```go
func (t *T) MethodName(argType T1, replyType *T2) error
```
这里的`T`、`T1`、`T2`要求能够被`encoding/gob`序列化，因此把加密后的数据放到`Encrypt`里面再传到`transfer`，然后又在`MetricValue`里面加了一个`Byte`来接受

