### PR TITLE
add API endpoint to update info of specific user

### DIFF
--- a/docs/_posts/User/2019-04-14-update-specific-user.md
+++ b/docs/_posts/User/2019-04-14-update-specific-user.md
@@ -1,7 +1,7 @@
 ---
 category: User
-apiurl: '/api/v1/user/update'
-title: 'Update User'
+apiurl: '/api/v1/user/u/:uid'
+title: 'Update Specific User'
 type: 'PUT'
 sample_doc: 'user.html'
 layout: default

--- a/modules/api/app/controller/uic/user_routes.go
+++ b/modules/api/app/controller/uic/user_routes.go
@@ -40,6 +40,7 @@ func Routes(r *gin.Engine) {
 	authapi.Use(utils.AuthSessionMidd)
 	authapi.GET("/current", UserInfo)
 	authapi.GET("/u/:uid", GetUser)
+	authapi.PUT("/u/:uid", UpdateUser)
 	authapi.GET("/name/:user_name", GetUserByName)
 	authapi.PUT("/update", UpdateCurrentUser)
 	authapi.PUT("/cgpasswd", ChangePassword)


### PR DESCRIPTION
Existing User update API endpoint `http://open-falcon.org/falcon-plus/#/user_update` is used to update info of login user. But in our integration development basing on Open Falcon Restful APIs, We found the need to have an endpoint to update info of users other than the login one.

Hope this endpoint is also useful to other users of open falcon