### PR TITLE
fix graph IndexCacheBase struct: remove not implemented maxSize Field

### DIFF
--- a/modules/graph/index/cache.go
+++ b/modules/graph/index/cache.go
@@ -32,14 +32,13 @@ import (
 )
 
 const (
-	DefaultMaxCacheSize                     = 5000000 // 默认 最多500w个,太大了内存会耗尽
 	DefaultCacheProcUpdateTaskSleepInterval = time.Duration(1) * time.Second
 )
 
 // item缓存
 var (
-	IndexedItemCache   = NewIndexCacheBase(DefaultMaxCacheSize)
-	unIndexedItemCache = NewIndexCacheBase(DefaultMaxCacheSize)
+	IndexedItemCache   = NewIndexCacheBase()
+	unIndexedItemCache = NewIndexCacheBase()
 )
 
 // db本地缓存
@@ -172,16 +171,11 @@ func NewIndexCacheItem(uuid string, item *cmodel.GraphItem) *IndexCacheItem {
 // 索引缓存-基本缓存容器
 type IndexCacheBase struct {
 	sync.RWMutex
-	maxSize int
-	data    map[string]interface{}
+	data map[string]interface{}
 }
 
-func NewIndexCacheBase(max int) *IndexCacheBase {
-	return &IndexCacheBase{maxSize: max, data: make(map[string]interface{})}
-}
-
-func (this *IndexCacheBase) GetMaxSize() int {
-	return this.maxSize
+func NewIndexCacheBase() *IndexCacheBase {
+	return &IndexCacheBase{data: make(map[string]interface{})}
 }
 
 func (this *IndexCacheBase) Put(key string, item interface{}) {


### PR DESCRIPTION
issue: https://github.com/open-falcon/falcon-plus/issues/477 有谈论到`IndexCacheBase`结构体的`maxSize`字段作用，代码中实际上没有实现对结构体大小做限制的功能，而且这个功能也不需要实现

`IndexedItemCache`存储所有被索引的metric信息，删掉其中的内容是没有意义的，在metric下次上报数据的时候还会由api中`index.ReceiveItem(items[i], checksum)`方法检测磁盘文件存在然后继续将metric数据塞进`IndexCacheBase`结构体