### PR TITLE
fix formatRedisAddr function bug: when password has separator character

### DIFF
--- a/modules/alarm/g/redis.go
+++ b/modules/alarm/g/redis.go
@@ -15,10 +15,11 @@
 package g
 
 import (
-	"github.com/garyburd/redigo/redis"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/garyburd/redigo/redis"
 )
 
 var RedisConnPool *redis.Pool
@@ -47,10 +48,10 @@ func InitRedisConnPool() {
 }
 
 func formatRedisAddr(addrConfig string) (string, string) {
-	if redisAddr := strings.Split(addrConfig, "@"); len(redisAddr) == 2 {
-		return redisAddr[0], redisAddr[1]
-	} else {
+	if redisAddr := strings.Split(addrConfig, "@"); len(redisAddr) == 1 {
 		return "", redisAddr[0]
+	} else {
+		return strings.Join(redisAddr[0:len(redisAddr)-1], "@"), redisAddr[len(redisAddr)-1]
 	}
 }
 

--- a/modules/judge/g/redis.go
+++ b/modules/judge/g/redis.go
@@ -15,10 +15,11 @@
 package g
 
 import (
-	"github.com/garyburd/redigo/redis"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/garyburd/redigo/redis"
 )
 
 var RedisConnPool *redis.Pool
@@ -57,10 +58,10 @@ func InitRedisConnPool() {
 }
 
 func formatRedisAddr(addrConfig string) (string, string) {
-	if redisAddr := strings.Split(addrConfig, "@"); len(redisAddr) == 2 {
-		return redisAddr[0], redisAddr[1]
-	} else {
+	if redisAddr := strings.Split(addrConfig, "@"); len(redisAddr) == 1 {
 		return "", redisAddr[0]
+	} else {
+		return strings.Join(redisAddr[0:len(redisAddr)-1], "@"), redisAddr[len(redisAddr)-1]
 	}
 }
 


### PR DESCRIPTION
pr: https://github.com/open-falcon/falcon-plus/pull/734 中`formatRedisAddr`方法有问题，没有考虑到redis密码包含`@`字符的情况

如果配置文件中redis的配置是`hello@world@127.0.0.1`(密码为`hello@world`，redis地址是`127.0.0.1`，密码包含`@`字符), 那么老的方法取到的redis密码是`hello`, redis的地址是`world`,实际上这样取到的值是完全错误的，这种情况下judge和alarm都不能正常工作
@laiwei