### PR TITLE
增加 -XGET 参数，指定 curl 请求方法，防止服务不支持 HEAD 方法时报 404

### DIFF
--- a/modules/agent/funcs/urlstat.go
+++ b/modules/agent/funcs/urlstat.go
@@ -49,7 +49,7 @@ func UrlMetrics() (L []*model.MetricValue) {
 }
 
 func probeUrl(furl string, timeout string) (bool, error) {
-	bs, err := sys.CmdOutBytes("curl", "--max-filesize", "102400", "-I", "-m", timeout, "-o", "/dev/null", "-s", "-w", "%{http_code}", furl)
+	bs, err := sys.CmdOutBytes("curl", "--max-filesize", "102400", "-I", "-XGET", "-m", timeout, "-o", "/dev/null", "-s", "-w", "%{http_code}", furl)
 	if err != nil {
 		log.Printf("probe url [%v] failed.the err is: [%v]\n", furl, err)
 		return false, err


### PR DESCRIPTION
在不支持 `HEAD` 方法的服务上使用 `url.check.health` 时会返回 404。由于 curl 增加 -I 参数后会使用 `HEAD` 方法请求，故增加 `-XGET` 参数。