### PR TITLE
[multi-platform] cross compile falcon-agent for non-X86 platform

### DIFF
--- a/modules/agent/funcs/funcs_x86.go
+++ b/modules/agent/funcs/funcs_x86.go
@@ -1,4 +1,4 @@
-// +build !386,!amd64
+// +build 386 amd64
 
 // Copyright 2017 Xiaomi, Inc.
 //
@@ -72,5 +72,6 @@ func BuildMappers() {
 			},
 			Interval: interval,
 		},
+		GpuMetricConf,
 	}
 }

--- a/modules/agent/funcs/gpu.go
+++ b/modules/agent/funcs/gpu.go
@@ -1,3 +1,5 @@
+// +build 386 amd64
+
 // Copyright 2017 Xiaomi, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +23,13 @@ import (
 	"github.com/open-falcon/falcon-plus/common/model"
 	"github.com/open-falcon/falcon-plus/modules/agent/g"
 )
+
+var GpuMetricConf = FuncsAndInterval{
+	Fs: []func() []*model.MetricValue{
+		GpuMetrics,
+	},
+	Interval: g.Config().Transfer.Interval,
+}
 
 // 需要load libnvidia-ml.so.1库
 func GpuMetrics() (L []*model.MetricValue) {


### PR DESCRIPTION
## Proposal

Met falcon-agent cross compile fail at modules/agent/funcs/gpu.go
```
$ GOOS=linux GOARCH=arm64 go build -o bin/agent/falcon-agent ./modules/agent
modules/agent/funcs/gpu.go:20:2: build constraints exclude all Go files in /Users/momouxin/Dev/go_project/src/github.com/open-falcon/falcon-plus/vendor/github.com/mindprince/gonvml
```

Consider about **agent/funcs/gpu.go** is only significant for `Nvidia GPU` on `X86 platform`, the **gnu.go should be only `build -tag` on x86 platform.**

## Solution

1. Add build tag `// +build 386 amd64` at `agent/funcs/gpu.go`
2. Withdraw **GpuMetrics** from BuildMappers() of agent/funcs/`funcs.go`, move to follow with `agent/funcs/gpu.go` together.
3. Double `agent/funcs/funcs.go` to `agent/funcs/funcs_x86.go`, `// +build !386,!amd64` for **funcs.go**, and `// +build 386 amd64` for **funcs_x86.go**

## Effection
> $ go build -o bin/agent/falcon-agent ./modules/agent; echo $?
0

> $ GOOS=linux GOARCH=arm64 go build -o bin/agent/falcon-agent ./modules/agent && file bin/agent/falcon-agent
bin/agent/falcon-agent: ELF 64-bit LSB executable, **ARM aarch64**, version 1 (SYSV), statically linked, not stripped

> $ GOOS=linux GOARCH=s390x go build -o bin/agent/falcon-agent ./modules/agent && file bin/agent/falcon-agent
bin/agent/falcon-agent: ELF 64-bit MSB executable, **IBM S/390**, version 1 (SYSV), statically linked, not stripped


Signed-off-by: gdmmx <gdmmx@163.com>