### PR TITLE
增加固定目录脚本采集方式(弥补插件功能)

### DIFF
--- a/modules/agent/cfg.example.json
+++ b/modules/agent/cfg.example.json
@@ -8,6 +8,12 @@
         "git": "https://github.com/open-falcon/plugin.git",
         "logs": "./logs"
     },
+    "script": {
+        "enabled": false,
+        "dir": "./scripts",
+        "reloadCfgFilesSec": 60,
+        "logs": "./logs"
+    },
     "heartbeat": {
         "enabled": true,
         "addr": "127.0.0.1:6030",

--- a/modules/agent/cron/script.go
+++ b/modules/agent/cron/script.go
@@ -1,0 +1,36 @@
+package cron
+
+import (
+    "github.com/open-falcon/falcon-plus/modules/agent/g"
+    "github.com/open-falcon/falcon-plus/modules/agent/scripts"
+    "log"
+    "time"
+)
+
+func SyncMineScripts() {
+    if !g.Config().Script.Enabled {
+        return
+    }
+
+    go syncMineScripts()
+}
+
+func syncMineScripts() {
+    duration := time.Duration(g.Config().Script.ReloadCfgFilesSec) * time.Second
+    for {
+        time.Sleep(duration)
+
+        desiredAll := make(map[string]*scripts.Script)
+        ps := scripts.ListScripts()
+        for k, p := range ps {
+            desiredAll[k] = p
+        }
+
+        scripts.DelNoUseScripts(desiredAll)
+        scripts.AddNewScripts(desiredAll)
+
+        if g.Config().Debug {
+            log.Printf("current scripts:%v\n", scripts.Scripts)
+        }
+    }
+}

--- a/modules/agent/g/cfg.go
+++ b/modules/agent/g/cfg.go
@@ -30,6 +30,13 @@ type PluginConfig struct {
 	LogDir  string `json:"logs"`
 }
 
+type ScriptConfig struct {
+	Enabled bool   `json:"enabled"`
+	Dir     string `json:"dir"`
+	ReloadCfgFilesSec int    `json:"reloadCfgFilesSec"`
+	LogDir  string `json:"logs"`
+}
+
 type HeartbeatConfig struct {
 	Enabled  bool   `json:"enabled"`
 	Addr     string `json:"addr"`
@@ -60,6 +67,7 @@ type GlobalConfig struct {
 	Hostname      string            `json:"hostname"`
 	IP            string            `json:"ip"`
 	Plugin        *PluginConfig     `json:"plugin"`
+	Script        *ScriptConfig     `json:"script`
 	Heartbeat     *HeartbeatConfig  `json:"heartbeat"`
 	Transfer      *TransferConfig   `json:"transfer"`
 	Http          *HttpConfig       `json:"http"`

--- a/modules/agent/main.go
+++ b/modules/agent/main.go
@@ -60,6 +60,7 @@ func main() {
 
 	cron.ReportAgentStatus()
 	cron.SyncMinePlugins()
+	cron.SyncMineScripts()
 	cron.SyncBuiltinMetrics()
 	cron.SyncTrustableIps()
 	cron.Collect()

--- a/modules/agent/scripts/reader.go
+++ b/modules/agent/scripts/reader.go
@@ -1,0 +1,64 @@
+package scripts
+
+import (
+	"github.com/open-falcon/falcon-plus/modules/agent/g"
+	"io/ioutil"
+	"log"
+	"strconv"
+	"strings"
+)
+
+const (
+	ScriptResultTypeJson = "json"
+	ScriptResultTypeLine = "line"
+	MetricTypeGAUGE = "GAUGE"
+	MetricTypeCOUNTER = "COUNTER"
+)
+
+// return: dict{./scripts/ntp_60_line.py : *Script}
+func ListScripts() map[string]*Script {
+	ret := make(map[string]*Script)
+
+	script_path := g.Config().Script.Dir
+	fs, err := ioutil.ReadDir(script_path)
+	if err != nil {
+		log.Println("can not list script files under", script_path)
+		return ret
+	}
+
+	for _, f := range fs {
+		if f.IsDir() {
+			continue
+		}
+
+		filename := f.Name()
+
+		arr := strings.Split(filename, "_")
+		larr := len(arr)
+		if larr < 3 {
+			continue
+		}
+
+		// filename should be: $name_$cycle_$resulttype.py
+		cycle, err := strconv.Atoi(arr[larr-2])
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		resultTypeArr := strings.Split(arr[larr-1], ".")
+		if len(resultTypeArr)<1 {
+			continue
+		}
+		resultType := resultTypeArr[0]
+		if resultType != ScriptResultTypeJson && resultType!= ScriptResultTypeLine {
+			continue
+		}
+
+		plugin := &Script{FilePath: filename, MTime: f.ModTime().Unix(), Cycle: cycle,
+			Args: "", ResultType:resultType}
+		ret[filename] = plugin
+	}
+
+	return ret
+}

--- a/modules/agent/scripts/scheduler.go
+++ b/modules/agent/scripts/scheduler.go
@@ -1,0 +1,241 @@
+package scripts
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+	"strconv"
+	"fmt"
+
+	"github.com/open-falcon/falcon-plus/common/model"
+	"github.com/open-falcon/falcon-plus/modules/agent/g"
+	"github.com/toolkits/file"
+	"github.com/toolkits/sys"
+)
+
+type ScriptScheduler struct {
+	Ticker *time.Ticker
+	Script *Script
+	Quit   chan struct{}
+}
+
+func NewScriptScheduler(p *Script) *ScriptScheduler {
+	scheduler := ScriptScheduler{Script: p}
+	scheduler.Ticker = time.NewTicker(time.Duration(p.Cycle) * time.Second)
+	scheduler.Quit = make(chan struct{})
+	return &scheduler
+}
+
+func (this *ScriptScheduler) Schedule() {
+	go func() {
+		for {
+			select {
+			case <-this.Ticker.C:
+				ScriptRun(this.Script)
+			case <-this.Quit:
+				this.Ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (this *ScriptScheduler) Stop() {
+	close(this.Quit)
+}
+
+// using ',' as the seprator of args and '\,' to espace
+func ScriptArgsParse(raw_args string) []string {
+	ss := strings.Split(raw_args, "\\,")
+
+	out := [][]string{}
+	for _, s := range ss {
+		clean_args := []string{}
+		for _, arg := range strings.Split(s, ",") {
+			arg = strings.Trim(arg, " ")
+			arg = strings.Trim(arg, "\"")
+			arg = strings.Trim(arg, "'")
+			clean_args = append(clean_args, arg)
+		}
+		out = append(out, clean_args)
+	}
+
+	ret := []string{}
+	tail := ""
+
+	for _, x := range out {
+		for j, y := range x {
+			if j == 0 {
+				if tail != "" {
+					ret = append(ret, tail+","+y)
+					tail = ""
+				} else {
+					ret = append(ret, y)
+				}
+			} else if j == len(x)-1 {
+				tail = y
+			} else {
+				ret = append(ret, y)
+			}
+		}
+	}
+
+	if tail != "" {
+		ret = append(ret, tail)
+	}
+
+	return ret
+}
+
+func ScriptRun(plugin *Script) {
+	timeout := plugin.Cycle*1000 - 500
+	fpath := filepath.Join(g.Config().Script.Dir, plugin.FilePath)
+	args := plugin.Args
+
+	if !file.IsExist(fpath) {
+		log.Printf("no such script: %s(%s)", fpath, args)
+		return
+	}
+
+	debug := g.Config().Debug
+	if debug {
+		log.Printf("%s(%s) running...", fpath, args)
+	}
+
+	var cmd *exec.Cmd
+	if args == "" {
+		cmd = exec.Command(fpath)
+	} else {
+		arg_list := ScriptArgsParse(args)
+		cmd = exec.Command(fpath, arg_list...)
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	err := cmd.Start()
+	if err != nil {
+		log.Printf("[ERROR] script start fail: %s(%s) , error: %s\n", fpath, args, err)
+		return
+	}
+	if debug {
+		log.Printf("script started: %s(%s)", fpath, args)
+	}
+
+	err, isTimeout := sys.CmdRunWithTimeout(cmd, time.Duration(timeout)*time.Millisecond)
+
+	errStr := stderr.String()
+	if errStr != "" {
+		logFile := filepath.Join(g.Config().Script.LogDir, plugin.FilePath+"("+plugin.Args+")"+".stderr.log")
+		if _, err = file.WriteString(logFile, errStr); err != nil {
+			log.Printf("[ERROR] write log to %s fail, error: %s\n", logFile, err)
+		}
+	}
+
+	if isTimeout {
+		// has be killed
+		if err == nil && debug {
+			log.Println("[INFO] timeout and kill process ", fpath, "(", args, ")", " successfully")
+		}
+
+		if err != nil {
+			log.Println("[ERROR] kill process ", fpath, "(", args, ")", " occur error:", err)
+		}
+
+		return
+	}
+
+	if err != nil {
+		log.Println("[ERROR] exec script", fpath, "(", args, ")", "fail. error:", err)
+		return
+	}
+
+	// exec successfully
+	data := stdout.Bytes()
+	if len(data) == 0 {
+		if debug {
+			log.Println("[DEBUG] stdout of", fpath, "(", args, ")", "is blank")
+		}
+		return
+	}
+
+	var metrics []*model.MetricValue
+	metrics, err = unmarshalScriptResult(data, plugin)
+	if err != nil {
+		log.Printf("[ERROR] unmarshal stdout of %s(%s) fail. error:%s stdout: \n%s\n", fpath, args, err, stdout.String())
+		return
+	}
+
+	if len(metrics)!=0 {
+		g.SendToTransfer(metrics)	
+	}
+}
+
+func unmarshalScriptResult(rbytes []byte, plugin *Script) ([]*model.MetricValue, error) {
+	var metrics []*model.MetricValue
+
+	// json
+	if plugin.ResultType == ScriptResultTypeJson {
+		err := json.Unmarshal(rbytes, &metrics)
+		return metrics, err
+	}
+
+	// line举例:
+	// codis_proxy_online: 1 : GAUGE
+	// codis_proxy_closed: 0 : COUNTER
+	// codis_proxy_ops_total: 6678532816
+	// codis_proxy_ops_fails: 520344
+	// codis_proxy_ops_qps: 226
+	// codis_proxy_ops_redis_errors: 843
+	// codis_proxy_sessions_total: 8028100437
+	// codis_proxy_sessions_alive: 44
+	if plugin.ResultType == ScriptResultTypeLine {
+		hostname, err := g.Hostname()
+		if err != nil {
+			return nil, err
+		}
+		ts := time.Now().Unix()
+
+		lines := strings.Split(string(rbytes), "\n")
+		for i:=0; i<len(lines); i++ {
+			line := strings.TrimSpace(lines[i])
+			pairs := strings.Split(line, ":")
+			if len(pairs) < 2 {
+				continue
+			}
+			metric := strings.TrimSpace(pairs[0])
+			valstr := strings.TrimSpace(pairs[1])
+			value, err := strconv.ParseFloat(valstr, 64)
+			if err != nil {
+				continue
+			}
+			mtype := "GAUGE"
+			if len(pairs)>=3 {
+				mtypeTmp := strings.TrimSpace(pairs[2])
+				if mtypeTmp == MetricTypeCOUNTER {
+					mtype = MetricTypeCOUNTER
+				}
+			}
+			metrics = append(metrics, &model.MetricValue{
+					Endpoint: hostname,
+					Metric: metric,
+					Value: value,
+					Step: int64(plugin.Cycle),
+					Type: mtype,
+					Tags: "",
+					Timestamp: ts,
+				})
+		}
+
+		return metrics, nil
+	}
+
+	return nil, fmt.Errorf("bad script result type %s", plugin.ResultType)
+}
+

--- a/modules/agent/scripts/scripts.go
+++ b/modules/agent/scripts/scripts.go
@@ -1,0 +1,51 @@
+package scripts
+
+type Script struct {
+	FilePath string
+	MTime    int64
+	Cycle    int
+	Args     string
+	ResultType string // text, json
+}
+
+var (
+	Scripts              = make(map[string]*Script)
+	ScriptsWithScheduler = make(map[string]*ScriptScheduler)
+)
+
+func DelNoUseScripts(newScripts map[string]*Script) {
+	for currKey, currScript := range Scripts {
+		newScript, ok := newScripts[currKey]
+		if !ok || currScript.MTime != newScript.MTime {
+			deleteScript(currKey)
+		}
+	}
+}
+
+func AddNewScripts(newScripts map[string]*Script) {
+	for fpath, newScript := range newScripts {
+		if _, ok := Scripts[fpath]; ok && newScript.MTime == Scripts[fpath].MTime {
+			continue
+		}
+
+		Scripts[fpath] = newScript
+		sch := NewScriptScheduler(newScript)
+		ScriptsWithScheduler[fpath] = sch
+		sch.Schedule()
+	}
+}
+
+func ClearAllScripts() {
+	for k := range Scripts {
+		deleteScript(k)
+	}
+}
+
+func deleteScript(key string) {
+	v, ok := ScriptsWithScheduler[key]
+	if ok {
+		v.Stop()
+		delete(ScriptsWithScheduler, key)
+	}
+	delete(Scripts, key)
+}


### PR DESCRIPTION
使用方式：
1. 在配置文件中，指定script配置项，主要是配置：脚本的存放目录（如./scripts）
2. 脚本命名方式为: $name_$cycle_$resulttype.py，其中
（1）$cycle为采集周期，单位秒
（2）$resulttype为脚本执行输出结果的类型，支持 json和line两种，见3中说明
3. 脚本输出类型
（1）json: 脚本输出json encode后的falcon数据点MetricValue数组；
（2）line: 每一行代表一个指标，形如 $metric_name: $value，支持多行；此方式不支持tags
