### PR TITLE
aggregator: pacing workers starting.

### DIFF
--- a/modules/aggregator/cron/worker.go
+++ b/modules/aggregator/cron/worker.go
@@ -16,6 +16,7 @@ package cron
 
 import (
 	"log"
+	"math/rand"
 	"time"
 
 	"github.com/open-falcon/falcon-plus/modules/aggregator/g"
@@ -29,7 +30,7 @@ type Worker struct {
 
 func NewWorker(ci *g.Cluster) Worker {
 	w := Worker{}
-	w.Ticker = time.NewTicker(time.Duration(ci.Step) * time.Second)
+	//	w.Ticker = time.NewTicker(time.Duration(ci.Step) * time.Second)
 	w.Quit = make(chan struct{})
 	w.ClusterItem = ci
 	return w
@@ -37,6 +38,17 @@ func NewWorker(ci *g.Cluster) Worker {
 
 func (this Worker) Start() {
 	go func() {
+		s1 := rand.NewSource(time.Now().UnixNano() * this.ClusterItem.Id)
+		r1 := rand.New(s1)
+		// 60s, step usually
+		delay := r1.Int63n(60000)
+
+		if g.Config().Debug {
+			log.Printf("[I] after %5d ms, start worker %d", delay, this.ClusterItem.Id)
+		}
+
+		time.Sleep(time.Duration(delay) * time.Millisecond)
+		this.Ticker = time.NewTicker(time.Duration(this.ClusterItem.Step) * time.Second)
 		for {
 			select {
 			case <-this.Ticker.C:

--- a/modules/aggregator/cron/worker.go
+++ b/modules/aggregator/cron/worker.go
@@ -30,7 +30,6 @@ type Worker struct {
 
 func NewWorker(ci *g.Cluster) Worker {
 	w := Worker{}
-	//	w.Ticker = time.NewTicker(time.Duration(ci.Step) * time.Second)
 	w.Quit = make(chan struct{})
 	w.ClusterItem = ci
 	return w
@@ -42,13 +41,13 @@ func (this Worker) Start() {
 		r1 := rand.New(s1)
 		// 60s, step usually
 		delay := r1.Int63n(60000)
-
 		if g.Config().Debug {
 			log.Printf("[I] after %5d ms, start worker %d", delay, this.ClusterItem.Id)
 		}
 
 		time.Sleep(time.Duration(delay) * time.Millisecond)
 		this.Ticker = time.NewTicker(time.Duration(this.ClusterItem.Step) * time.Second)
+
 		for {
 			select {
 			case <-this.Ticker.C:


### PR DESCRIPTION
Aggregator reports about 80 tasks "i/o timeout" , when cluster tasks more then 500, and CPU momentary value >180% . By pacing workers starting, solved this problem and CPU momentary value < 20%.

submit link: aggregator: pacing workers starting #806