### PR TITLE
fix(monitor): incorrect path to log file

### DIFF
--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -41,7 +41,7 @@ func checkMonReq(name string) error {
 	}
 
 	if !g.HasLogfile(name) {
-		r := g.Rel(g.Cfg(name))
+		r := g.Rel(g.LogPath(name))
 		return fmt.Errorf("expect logfile: %s", r)
 	}
 


### PR DESCRIPTION
Using command `open-falcon monitor`, and it's output as
follows:

```
...

expect logfile:
agent/config/cfg.json
```

Expected:

```
...
expect logfile:
agent/logs/agent.log
```