### PR TITLE
fix issue #832

### DIFF
--- a/common/backend_pool/tsdb_backends.go
+++ b/common/backend_pool/tsdb_backends.go
@@ -24,7 +24,7 @@ import (
 
 // TSDB
 type TsdbClient struct {
-	cli  net.Conn
+	cli  *struct{ net.Conn }
 	name string
 }
 
@@ -33,13 +33,13 @@ func (t TsdbClient) Name() string {
 }
 
 func (t TsdbClient) Closed() bool {
-	return t.cli == nil
+	return t.cli.Conn == nil
 }
 
 func (t TsdbClient) Close() error {
 	if t.cli != nil {
 		err := t.cli.Close()
-		t.cli = nil
+		t.cli.Conn = nil
 		return err
 	}
 	return nil
@@ -59,7 +59,10 @@ func newTsdbConnPool(address string, maxConns int, maxIdle int, connTimeout int)
 			return nil, err
 		}
 
-		return TsdbClient{conn, name}, nil
+		return TsdbClient{
+			cli:  &struct{ net.Conn }{conn},
+			name: name,
+		}, nil
 	}
 
 	return pool


### PR DESCRIPTION
TsdbClient 由于要放进连接池，需要实现 NConn 接口；而 NConn 接口中的 Name() Closed() 和 io.Closer 中的 Close() 等 method signature 的 receiver 都不是指针。
秉持不修改接口的原则，这里我尝试把 cli 的 net.Conn 封装到一个结构体里面，cli本身使用指针，实现在基础类型 receiver 里修改 struct 内的 field。