### PR TITLE
fix: rpc server enable keepalive

### DIFF
--- a/modules/gateway/receiver/rpc/rpc.go
+++ b/modules/gateway/receiver/rpc/rpc.go
@@ -45,11 +45,13 @@ func StartRpc() {
 	server.Register(new(Transfer))
 
 	for {
-		conn, err := listener.Accept()
+		conn, err := listener.AcceptTCP()
 		if err != nil {
 			log.Println("listener.Accept occur error:", err)
 			continue
 		}
+
+		conn.SetKeepAlive(true)
 		// go rpc.ServeConn(conn)
 		go server.ServeCodec(jsonrpc.NewServerCodec(conn))
 	}

--- a/modules/gateway/receiver/socket/socket.go
+++ b/modules/gateway/receiver/socket/socket.go
@@ -42,12 +42,13 @@ func StartSocket() {
 	defer listener.Close()
 
 	for {
-		conn, err := listener.Accept()
+		conn, err := listener.AcceptTCP()
 		if err != nil {
 			log.Println("listener.Accept occur error:", err)
 			continue
 		}
 
+		conn.SetKeepAlive(true)
 		go socketTelnetHandle(conn)
 	}
 }

--- a/modules/graph/api/rpc.go
+++ b/modules/graph/api/rpc.go
@@ -73,7 +73,7 @@ func Start() {
 	go func() {
 		var tempDelay time.Duration // how long to sleep on accept failure
 		for {
-			conn, err := listener.Accept()
+			conn, err := listener.AcceptTCP()
 			if err != nil {
 				if tempDelay == 0 {
 					tempDelay = 5 * time.Millisecond
@@ -86,6 +86,8 @@ func Start() {
 				time.Sleep(tempDelay)
 				continue
 			}
+
+			conn.SetKeepAlive(true)
 			tempDelay = 0
 			go func() {
 				e := connects.insert(conn)

--- a/modules/transfer/receiver/rpc/rpc.go
+++ b/modules/transfer/receiver/rpc/rpc.go
@@ -44,11 +44,13 @@ func StartRpc() {
 	server.Register(new(Transfer))
 
 	for {
-		conn, err := listener.Accept()
+		conn, err := listener.AcceptTCP()
 		if err != nil {
 			log.Println("listener.Accept occur error:", err)
 			continue
 		}
+
+		conn.SetKeepAlive(true)
 		go server.ServeCodec(jsonrpc.NewServerCodec(conn))
 	}
 }

--- a/modules/transfer/receiver/socket/socket.go
+++ b/modules/transfer/receiver/socket/socket.go
@@ -41,12 +41,13 @@ func StartSocket() {
 	defer listener.Close()
 
 	for {
-		conn, err := listener.Accept()
+		conn, err := listener.AcceptTCP()
 		if err != nil {
 			log.Println("listener.Accept occur error:", err)
 			continue
 		}
 
+		conn.SetKeepAlive(true)
 		go socketTelnetHandle(conn)
 	}
 }


### PR DESCRIPTION
修复因为 rcp server  没有开启 keepalive 导致大量 ESTABLISHED 连接没法自动关闭，从而新的请求超时的问题。https://github.com/open-falcon/falcon-plus/issues/630

问题排查过程参考：https://hansedong.github.io/2018/11/16/8/