### PR TITLE
Add `ens` ifacePrefix in cfg.json.example

### DIFF
--- a/modules/agent/cfg.example.json
+++ b/modules/agent/cfg.example.json
@@ -29,7 +29,7 @@
         "backdoor": false
     },
     "collector": {
-        "ifacePrefix": ["eth", "em"],
+        "ifacePrefix": ["eth", "em", "ens"],
         "mountPoint": []
     },
     "default_tags": {


### PR DESCRIPTION
`ens` prefix is used for PCI Express network interface. Since it has been common, I suggest to add it as default in agent's sample config.