### PR TITLE
mysql初始化通过容器进行

### DIFF
--- a/docker/mysql-init/Dockerfile
+++ b/docker/mysql-init/Dockerfile
@@ -1,0 +1,10 @@
+from alpine:3.5
+
+env MYSQL_HOST=mysql \
+    MYSQL_USER=root \
+    MYSQL_PASSWORD=123456
+
+run apk add --no-cache mysql-client git
+copy init_mysql_data.sh /
+
+cmd ["/init_mysql_data.sh"]

--- a/docker/mysql-init/Dockerfile
+++ b/docker/mysql-init/Dockerfile
@@ -2,7 +2,7 @@ from alpine:3.5
 
 env MYSQL_HOST=mysql \
     MYSQL_USER=root \
-    MYSQL_PASSWORD=123456
+    MYSQL_PASSWORD=test123456
 
 run apk add --no-cache mysql-client git
 copy init_mysql_data.sh /

--- a/docker/mysql-init/init_mysql_data.sh
+++ b/docker/mysql-init/init_mysql_data.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+Host=${MYSQL_HOST}
+User=${MYSQL_USER}
+Password=${MYSQL_PASSWORD}
+
+cd /tmp && \
+        git clone --depth=1 https://github.com/open-falcon/falcon-plus && \
+        cd /tmp/falcon-plus/ && \
+        for x in `ls ./scripts/mysql/db_schema/*.sql`; do
+            echo init mysql table $x ...;
+            mysql -h${Host} -u${User} -p${Password} < $x;
+        done
+
+rm -rf /tmp/falcon-plus/


### PR DESCRIPTION
issue:
https://github.com/open-falcon/falcon-plus/issues/857

docker或kubernetes部署，mysql初始化应该用容器方式进行。