### PR TITLE
Correct the mismatch between the json token "values" in GraphAccurate…

### DIFF
--- a/common/model/graph.go
+++ b/common/model/graph.go
@@ -104,7 +104,7 @@ type GraphAccurateQueryParam struct {
 }
 
 type GraphAccurateQueryResponse struct {
-	Values []*RRDData `json:"values"`
+	Values []*RRDData `json:"Values"`
 }
 
 type JsonFloat float64


### PR DESCRIPTION
When the migration switch is on, the Graph.Query always return nil when the server is responding the correct the values.

The reason is the mismatch of json token in GraphAccurateQueryResponse and GraphQueryResponse.

This PR corrects it .