### PR TITLE
修复 cmd/start.go isStarted() 函数超时判断无用BUG。

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -95,13 +95,14 @@ func checkStartReq(name string) error {
 func isStarted(name string) bool {
 	ticker := time.NewTicker(time.Millisecond * 100)
 	defer ticker.Stop()
+	timeout := time.After(time.Second)
 	for {
 		select {
 		case <-ticker.C:
 			if g.IsRunning(name) {
 				return true
 			}
-		case <-time.After(time.Second):
+		case <-timeout:
 			return false
 		}
 	}


### PR DESCRIPTION
问题复现代码

```go
package main

import (
	"fmt"
	"time"
)

var b bool

func main() {
	go setB()
	test()
}

func setB() {
	time.AfterFunc(10*time.Second, func() {
		fmt.Println("set true")
		b = true
	})
}

func test() bool {
	ticker := time.NewTicker(time.Millisecond * 100)
	defer ticker.Stop()
	//timeout := time.After(time.Second)
	for {
		select {
		case <-ticker.C:
			if IsRunning() {
				return true
			}
		case <-time.After(time.Second):
			fmt.Println("timeout")
			return false
		}
	}
}

func IsRunning() bool {
	//<-time.After(2 * time.Second)
	return b
}

```