### PR TITLE
增加 k8s 集群部署方式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out/
 docs/_site
 .idea
 open-falcon
+build

--- a/docker/k8s-cluster/Dockerfile.tpl
+++ b/docker/k8s-cluster/Dockerfile.tpl
@@ -1,0 +1,14 @@
+FROM alpine:3.7
+LABEL maintainer tabsp@qq.com
+USER root
+
+ENV FALCON_DIR=/open-falcon
+# agent
+RUN apk add --no-cache ca-certificates git curl
+# alarm
+ADD https://github.com/golang/go/raw/master/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
+
+COPY build/%%MODULE_NAME%% ${FALCON_DIR}/%%MODULE_NAME%%
+WORKDIR ${FALCON_DIR}
+
+CMD ["/open-falcon/%%MODULE_NAME%%/bin/falcon-%%MODULE_NAME%%", "-c", "/open-falcon/%%MODULE_NAME%%/config/cfg.json"]

--- a/docker/k8s-cluster/README.md
+++ b/docker/k8s-cluster/README.md
@@ -1,0 +1,23 @@
+## 分布式部署 open-falcon 到 k8s 集群
+
+### 构建
+
+克隆源码：
+
+```shell
+git clone https://github.com/open-falcon/falcon-plus.git && cd falcon-plus 
+```
+
+编译源码并构建 Docker 镜像
+
+```shell
+./docker/k8s-cluster/build.sh
+```
+
+### 部署
+
+注意点：
+
+1. graph 为有状态组件，部署方式为每个节点一个 Deployment，同时 replica 设置为 1
+2. 所有配置文件使用挂载目录的方式持久化，可以改为 ConfigMap 管理配置
+3. 镜像可以使用构建脚本自己构建后推送到自己的私仓使用（推荐），或者直接使用我构建好的，仓库地址在 docker/k8s-cluster/build.sh 查看或修改

--- a/docker/k8s-cluster/build.sh
+++ b/docker/k8s-cluster/build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+MODULES=(
+    'agent'
+    'aggregator'
+    'alarm'
+    'api'
+    'gateway'
+    'graph'
+    'hbs'
+    'judge'
+    'nodata'
+    'transfer'
+)
+DOCKER_REGISTRY=registry.cn-hangzhou.aliyuncs.com/open-falcon
+VERSION=v0.3
+
+clean() {
+    echo "clean..."
+    if [ -d "build" ]; then
+        rm -rf build/
+    fi
+    mkdir build
+}
+
+build() {
+    echo "build source..."
+    docker run -it --rm \
+        --name build \
+        -v "$(pwd)":"/go/src/github.com/open-falcon/falcon-plus" \
+        -w "/go/src/github.com/open-falcon/falcon-plus" \
+        openfalcon/makegcc-golang:1.10-alpine \
+        docker/k8s-cluster/init.sh
+}
+
+buildDockerImages() {
+    echo "build docker images..."
+    for i in "${MODULES[@]}"; do
+        echo "build $i"
+        awk -v module="$i" '{ gsub(/%%MODULE_NAME%%/, module); print $0 }' docker/k8s-cluster/Dockerfile.tpl > docker/k8s-cluster/Dockerfile
+        docker build -f docker/k8s-cluster/Dockerfile -t $DOCKER_REGISTRY/$i:$VERSION .
+        rm docker/k8s-cluster/Dockerfile
+    done
+}
+
+clean
+build
+buildDockerImages

--- a/docker/k8s-cluster/init.sh
+++ b/docker/k8s-cluster/init.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+apk add --no-cache ca-certificates git bash \
+&& make all \
+&& make pack4docker \
+&& tar -zxf open-falcon-v*.tar.gz -C build \
+&& rm open-falcon-v*.tar.gz

--- a/docker/k8s-cluster/modules/falcon-agent.yaml
+++ b/docker/k8s-cluster/modules/falcon-agent.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-agent
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 1988
+  selector:
+    name: falcon-agent
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-agent
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-agent
+    spec:
+      containers:
+        - name: falcon-agent
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/agent:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 1988
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/agent/config
+              name: falcon-agent-config
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-agent/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-agent-config
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-aggregator.yaml
+++ b/docker/k8s-cluster/modules/falcon-aggregator.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-aggregator
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 6055
+  selector:
+    name: falcon-aggregator
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-aggregator
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-aggregator
+    spec:
+      containers:
+        - name: falcon-aggregator
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/aggregator:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6055
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/aggregator/config
+              name: falcon-aggregator-config
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-aggregator/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-aggregator-config
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-alarm.yaml
+++ b/docker/k8s-cluster/modules/falcon-alarm.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-alarm
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9912
+  selector:
+    name: falcon-alarm
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-alarm
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-alarm
+    spec:
+      containers:
+        - name: falcon-alarm
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/alarm:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9912
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/alarm/config
+              name: falcon-alarm-config
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-alarm/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-alarm-config
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-api.yaml
+++ b/docker/k8s-cluster/modules/falcon-api.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-api
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+  selector:
+    name: falcon-api
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-api
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-api
+    spec:
+      containers:
+        - name: falcon-api
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/api:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/api/config
+              name: falcon-api-config
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-api/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-api-config
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-dashboard.yaml
+++ b/docker/k8s-cluster/modules/falcon-dashboard.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-dashboard
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8081
+  selector:
+    name: falcon-dashboard
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-dashboard
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-dashboard
+    spec:
+      containers:
+      - name: falcon-dashboard
+        image: openfalcon/falcon-dashboard:v0.2.1
+        command: ["sh","-c","cd /open-falcon/dashboard &&  ./control startfg"]
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+        env:
+        - name: API_ADDR
+          value: http://falcon-api:8080/api/v1
+        - name: PORTAL_DB_HOST
+          value: 127.0.0.1
+        - name: PORTAL_DB_PORT
+          value: "3306"
+        - name: PORTAL_DB_USER
+          value: root
+        - name: PORTAL_DB_PASS
+          value: xxx
+        - name: PORTAL_DB_NAME
+          value: falcon_portal
+        - name: ALARM_DB_HOST
+          value: 127.0.0.1
+        - name: ALARM_DB_PORT
+          value: "3306"
+        - name: ALARM_DB_USER
+          value: root
+        - name: ALARM_DB_PASS
+          value: root
+        - name: ALARM_DB_NAME
+          value: alarms
+        volumeMounts:
+          - mountPath: /etc/localtime
+            name: tz-config
+      volumes:
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-graph-01.yaml
+++ b/docker/k8s-cluster/modules/falcon-graph-01.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-graph-01
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: rpc
+      port: 6070
+    - name: http
+      port: 6071
+  selector:
+    name: falcon-graph-01
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-graph-01
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-graph-01
+    spec:
+      containers:
+        - name: falcon-graph-01
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/graph:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6070
+              name: rpc
+              protocol: TCP
+            - containerPort: 6071
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/graph/config
+              name: falcon-graph-config
+            - mountPath: /open-falcon/graph/data
+              name: falcon-graph-data
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-graph/01/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-graph-config
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-graph/01/data
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-graph-data
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-hbs.yaml
+++ b/docker/k8s-cluster/modules/falcon-hbs.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-hbs
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: rpc
+      port: 6030
+    - name: http
+      port: 6031
+  selector:
+    name: falcon-hbs
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-hbs
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-hbs
+    spec:
+      containers:
+        - name: falcon-hbs
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/hbs:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6030
+              name: rpc
+              protocol: TCP
+            - containerPort: 6031
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/hbs/config
+              name: falcon-hbs-config
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-hbs/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-hbs-config
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-judge.yaml
+++ b/docker/k8s-cluster/modules/falcon-judge.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-judge
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: rpc
+      port: 6080
+    - name: http
+      port: 6081
+  selector:
+    name: falcon-judge
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-judge
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-judge
+    spec:
+      containers:
+        - name: falcon-judge
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/judge:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6080
+              name: rpc
+              protocol: TCP
+            - containerPort: 6081
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/judge/config
+              name: falcon-judge-config
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-judge/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-judge-config
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-nodata.yaml
+++ b/docker/k8s-cluster/modules/falcon-nodata.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-nodata
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 6090
+  selector:
+    name: falcon-nodata
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-nodata
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-nodata
+    spec:
+      containers:
+        - name: falcon-nodata
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/nodata:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6090
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/nodata/config
+              name: falcon-nodata-config
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-nodata/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-nodata-config
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config

--- a/docker/k8s-cluster/modules/falcon-transfer.yaml
+++ b/docker/k8s-cluster/modules/falcon-transfer.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-falcon
+  name: falcon-transfer
+  labels:
+    app: open-falcon
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 6060
+    - name: rpc
+      port: 8433
+  selector:
+    name: falcon-transfer
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: open-falcon
+  name: falcon-transfer
+  labels:
+    app: open-falcon
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: falcon-transfer
+    spec:
+      containers:
+        - name: falcon-transfer
+          image: registry.cn-hangzhou.aliyuncs.com/open-falcon/transfer:v0.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6060
+              name: http
+              protocol: TCP
+            - containerPort: 8433
+              name: rpc
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /open-falcon/transfer/config
+              name: falcon-transfer-config
+            - mountPath: /etc/localtime
+              name: tz-config
+      volumes:
+        - flexVolume:
+            driver: alicloud/nas
+            options:
+              path: /open-falcon/falcon-transfer/config
+              server: xxx.cn-hangzhou.nas.aliyuncs.com
+              vers: "4.0"
+          name: falcon-transfer-config
+        - hostPath:
+            path: /etc/localtime
+            type: ''
+          name: tz-config


### PR DESCRIPTION
现有仓库中的 [k8s-example](https://github.com/open-falcon/falcon-plus/tree/master/docker/k8s-example) 本质上是单机部署，我提供了一个利用 k8s 分布式部署例子。