### PR TITLE
新增两个告警函数

### DIFF
--- a/modules/judge/store/func.go
+++ b/modules/judge/store/func.go
@@ -307,7 +307,7 @@ func (this PDiffFunction) Compute(L *SafeLinkedList) (vs []*model.HistoryData, l
 
 type KPDiffFunction struct {
 	Function
-	Num		   int
+	Num        int
 	Limit      int
 	Operator   string
 	RightValue float64


### PR DESCRIPTION

新增两个告警函数 kpdiff(#3,3)  kdiff(#3,3) 
kpdiff(#3,3)   kdiff(#3,3)    左边的3是指稳定数据走势的数据点，右边的3是指持续变化的数据点
用于告警类似下面的数据模型，解决当某个指标稳定的情况下，突然飙高或者降低，并且是持续的情况下，就告警。原来的diff 和 pdiff只要一个点就告警，不是持续才告警

```
             3
           ______
         /
   3    /
_______
```

