### PR TITLE
Delete the end of the src path /  in ln -s cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ pack: checkbin
 	@$(foreach var,$(CMD),cp ./config/$(var).json ./out/$(var)/config/cfg.json;)
 	@$(foreach var,$(CMD),cp ./bin/$(var)/falcon-$(var) ./out/$(var)/bin;)
 	@cp -r ./modules/agent/public ./out/agent/
-	@(cd ./out && ln -s ./agent/public/ ./public)
-	@(cd ./out && mkdir -p ./agent/plugin && ln -s ./agent/plugin/ ./plugin)
+	@(cd ./out && ln -s ./agent/public ./public)
+	@(cd ./out && mkdir -p ./agent/plugin && ln -s ./agent/plugin ./plugin)
 	@cp -r ./modules/api/data ./out/api/
 	@mkdir out/graph/data
 	@bash ./config/confgen.sh
@@ -80,8 +80,8 @@ pack4docker: checkbin
 	@$(foreach var,$(CMD),cp ./bin/$(var)/falcon-$(var) ./out/$(var)/bin;)
 	@if expr "$(CMD)" : "agent" > /dev/null; then \
 		(cp -r ./modules/agent/public ./out/agent/); \
-		(cd ./out && ln -s ./agent/public/ ./public); \
-		(cd ./out && mkdir -p ./agent/plugin && ln -s ./agent/plugin/ ./plugin); \
+		(cd ./out && ln -s ./agent/public ./public); \
+		(cd ./out && mkdir -p ./agent/plugin && ln -s ./agent/plugin ./plugin); \
 	fi
 	@if expr "$(CMD)" : "api" > /dev/null; then \
 		cp -r ./modules/api/data ./out/api/; \


### PR DESCRIPTION
删除源路径结尾的 /

```


work@work-hp:~/open-falcon$ /bin/ls -lF
total 71388
drwxr-xr-x 7 work work     4096 May 30  2019 agent/
drwxr-xr-x 5 work work     4096 May 30  2019 aggregator/
drwxr-xr-x 5 work work     4096 May 30  2019 alarm/
drwxr-xr-x 6 work work     4096 May 30  2019 api/
drwxr-xr-x 5 work work     4096 May 30  2019 gateway/
drwxr-xr-x 6 work work     4096 May 30  2019 graph/
drwxr-xr-x 5 work work     4096 May 30  2019 hbs/
drwxr-xr-x 5 work work     4096 May 30  2019 judge/
drwxr-xr-x 5 work work     4096 May 30  2019 nodata/
-rwxr-xr-x 1 work work  4370880 May 30  2019 open-falcon*
-rw-rw-r-- 1 work work 68685265 Nov 26 14:37 open-falcon-v0.3.tar.gz
lrwxrwxrwx 1 work work       15 May 30  2019 plugin -> ./agent/plugin//
lrwxrwxrwx 1 work work       15 May 30  2019 public -> ./agent/public//          原路径 / 结尾的话，弄出来的软连接 这能看到 2个 /  结尾了。
drwxr-xr-x 5 work work     4096 May 30  2019 transfer/
work@work-hp:~/open-falcon$ 

```

